### PR TITLE
CI: add better integration on GitHub Actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: Tests
+name: Build
 on:
   push:
     branches:
@@ -13,8 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      checks: write
     steps:
       - uses: actions/checkout@v3
 
@@ -23,6 +21,11 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
+      - name: Restore Maven cache
+        uses: skjolber/maven-cache-github-action@v1
+        with:
+          step: restore
+
       - name: Maven Build
         run: mvn clean package
 
@@ -30,11 +33,38 @@ jobs:
         run: mvn validate
 
       - name: Maven Test
+        id: test
         run: |
           mvn test --file ./pom.xml
           mvn jacoco:report-aggregate
 
-      - name: JaCoCo Code Coverage Report
+      - name: Upload current-info
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: |
+            ${{ github.workspace }}/coverage/target/site/jacoco-aggregate/jacoco.xml
+            ${{ github.workspace }}/notification-service/target/*.jar
+            ${{ github.workspace }}/workflow-service/target/*.jar
+
+      - name: Save Maven cache
+        uses: skjolber/maven-cache-github-action@v1
+        with:
+          step: save
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    permissions:
+      checks: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+
+      - name: "JaCoCo Code Coverage Report ${{ needs.build.outputs.test }}"
         id: jacoco_reporter
         uses: PavanMudigonda/jacoco-reporter@v4.8
         with:
@@ -49,3 +79,90 @@ jobs:
 
       - name: Add Coverage Job Summary
         run: echo "${{ steps.jacoco_reporter.outputs.coverageSummary }}" >> $GITHUB_STEP_SUMMARY
+
+  containers:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts
+
+      - name: "Build container images to quay ${{ needs.build.outputs.test }}"
+        run: |
+          make build-images
+
+      - name: Upload image
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "docker-compose_workflow-service:latest"
+
+      - name: Upload image
+        uses: ishworkh/docker-image-artifact-upload@v1
+        with:
+          image: "docker-compose_notification-service:latest"
+
+      - name: "finished"
+        id: container-finished
+        run: echo 1
+
+  integration:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: "v0.16.0"
+
+      - name: Waiting for kind to be ready
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+
+      - name: Install kubernetes dependencies
+        run: |
+          make install-kubernetes-dependencies
+          make wait-kubernetes-dependencies
+
+      - id: wait-for-jobs
+        uses: yogeshlonkar/wait-for-jobs@v0
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          jobs: |
+            containers
+
+      - name: Download images
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "docker-compose_notification-service:latest"
+
+      - name: Download images
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "docker-compose_workflow-service:latest"
+
+      - name: Load images inside kind
+        run: |
+          make push-images-to-kind
+
+      - name: Deploy
+        run: |
+          kubectl kustomize hack/manifests/testing| kubectl apply -f -
+          kubectl wait --timeout=120s --for=condition=Ready pods --all -n default
+          kubectl get pods --all-namespaces
+
+      - name: Run example script
+        run: |
+          export SERVERIP=$(kubectl get nodes kind-control-plane -o json  |  jq -r '[.status.addresses[] | select(.type=="InternalIP")] | .[0].address')
+          SERVER_IP="${SERVERIP}" SERVERPORT=80 ./workflow-examples/run_examples.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+
+COMPOSE ?= docker-compose
+DOCKER ?= docker
+
+ORG=quay.io/parados/
+WORKFLOW_SERVICE_IMAGE=workflow-service
+NOTIFICATION_SERVICE_IMAGE=notification-service
+
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD | sed s,^main$$,latest,g)
+GIT_HASH := $(shell git rev-parse HEAD)
+
+build-images:
+	$(COMPOSE) -f ./docker-compose/docker-compose.yml build
+
+
+tag-images:
+	$(DOCKER) tag docker-compose_workflow-service:latest $(ORG)$(WORKFLOW_SERVICE_IMAGE):$(GIT_HASH)
+	$(DOCKER) tag docker-compose_notification-service:latest $(ORG)$(NOTIFICATION_SERVICE_IMAGE):$(GIT_HASH)
+
+	$(DOCKER) tag docker-compose_workflow-service:latest $(ORG)$(WORKFLOW_SERVICE_IMAGE):$(GIT_BRANCH)
+	$(DOCKER) tag docker-compose_notification-service:latest $(ORG)$(NOTIFICATION_SERVICE_IMAGE):$(GIT_BRANCH)
+
+push-images:
+	$(DOCKER) push  $(ORG)/$(WORKFLOW_SERVICE_IMAGE):$(GIT_HASH)
+	$(DOCKER) push  $(ORG)/$(NOTIFICATION_SERVICE_IMAGE):$(GIT_HASH)
+
+	$(DOCKER) push  $(ORG)/$(WORKFLOW_SERVICE_IMAGE):$(GIT_BRANCH)
+	$(DOCKER) push  $(ORG)/$(NOTIFICATION_SERVICE_IMAGE):$(GIT_BRANCH)
+
+push-images-to-kind:
+	$(DOCKER) tag docker-compose_workflow-service:latest $(ORG)$(WORKFLOW_SERVICE_IMAGE):test
+	$(DOCKER) tag docker-compose_notification-service:latest $(ORG)$(NOTIFICATION_SERVICE_IMAGE):test
+	kind load docker-image $(ORG)$(WORKFLOW_SERVICE_IMAGE):test
+	kind load docker-image $(ORG)$(NOTIFICATION_SERVICE_IMAGE):test
+
+install-nginx:
+	kubectl label node kind-control-plane  "ingress-ready=true" || exit 0
+	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+install-kubernetes-dependencies: install-nginx
+
+wait-kubernetes-dependencies:
+	kubectl wait --namespace ingress-nginx \
+	  --for=condition=ready pod \
+	  --selector=app.kubernetes.io/component=controller \
+	  --timeout=90s

--- a/hack/manifests/base/deployment.yaml
+++ b/hack/manifests/base/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+spec:
+  selector:
+    matchLabels:
+      app: notification-service
+  template:
+    metadata:
+      labels:
+        app: notification-service
+    spec:
+      containers:
+      - name: notification-service
+        image: quay.io/parados/notification-service:latest
+        env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: "local"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: workflow-service
+spec:
+  selector:
+    matchLabels:
+      app: workflow-service
+  template:
+    metadata:
+      labels:
+        app: workflow-service
+    spec:
+      containers:
+      - name: workflow-service
+        image: quay.io/parados/workflow-service:latest
+        env:
+          - name: SPRING_PROFILES_ACTIVE
+            value: "local"

--- a/hack/manifests/base/kustomization.yaml
+++ b/hack/manifests/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- deployment.yaml
+- services.yaml

--- a/hack/manifests/base/services.yaml
+++ b/hack/manifests/base/services.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workflow-service
+spec:
+  selector:
+    app: workflow-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+spec:
+  selector:
+    app: notification-service
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080

--- a/hack/manifests/testing/ingress.yaml
+++ b/hack/manifests/testing/ingress.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: parados-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: workflow-service
+            port:
+              number: 8080

--- a/hack/manifests/testing/kustomization.yaml
+++ b/hack/manifests/testing/kustomization.yaml
@@ -1,0 +1,12 @@
+bases:
+- ../base
+resources:
+- ingress.yaml
+images:
+- name: quay.io/parados/workflow-service:latest
+  newTag: test
+
+- name: quay.io/parados/notification-service:latest
+  newTag: test
+
+


### PR DESCRIPTION
This change adds a way to test the following things in GitHub actions:

- Build using maven build as it was.
- A new job to report jacoco reports.
- A super simple way to deploy things to kubernetes for example.
- A simple way to run the example script.
- A big refactor on example script with colors and assertions.
- Added cache on maven when build

The workflow is like this one:
https://github.com/redhat-developer/parodos/actions/runs/4232739123