### PR TITLE
CI: Fix checkout on workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,20 @@ on:
   push:
     branches:
       - main
+      - ActionsTest
       - 'releases/**'
 
   pull_request_target:
     branches:
       - '**'
-
+permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha != '' &&  github.event.pull_request.head.sha ||  github.sha }}
 
       - uses: actions/setup-java@v3
         with:
@@ -87,6 +90,8 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha != '' &&  github.event.pull_request.head.sha ||  github.sha }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -116,8 +121,9 @@ jobs:
     needs:
       - build
     steps:
-
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha != '' &&  github.event.pull_request.head.sha ||  github.sha }}
 
       - uses: engineerd/setup-kind@v0.5.0
         with:

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/execution/service/WorkFlowServiceImplTest.java
@@ -39,18 +39,15 @@ class WorkFlowServiceImplTest {
 		this.workFlowTaskRepository = Mockito.mock(WorkFlowTaskRepository.class);
 		this.workFlowDelegate = Mockito.mock(WorkFlowDelegate.class);
 
-		this.workFlowService = new WorkFlowServiceImpl(this.workFlowDelegate, this.workFlowDefinitionRepository, this.workFlowRepository, this.workFlowTaskRepository);
+		this.workFlowService = new WorkFlowServiceImpl(this.workFlowDelegate, this.workFlowDefinitionRepository,
+				this.workFlowRepository, this.workFlowTaskRepository);
 	}
 
 	@Test
 	void executeTestwithValidData() {
 		// given
 		Work work = Mockito.mock(Work.class);
-		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow()
-				.named("test")
-				.execute(work)
-				.build();
-
+		SequentialFlow workFlow = SequentialFlow.Builder.aNewSequentialFlow().named("test").execute(work).build();
 
 		Mockito.when(work.execute(Mockito.any()))
 				.thenReturn(new DefaultWorkReport(WorkStatus.COMPLETED, new WorkContext() {
@@ -59,7 +56,8 @@ class WorkFlowServiceImplTest {
 					}
 				}));
 		Mockito.when(this.workFlowDelegate.getWorkFlowExecutionByName("test-workflow")).thenReturn(workFlow);
-		Mockito.when(this.workFlowDelegate.getWorkFlowContext(Mockito.any(), Mockito.any())).thenReturn(new WorkContext());
+		Mockito.when(this.workFlowDelegate.getWorkFlowContext(Mockito.any(), Mockito.any()))
+				.thenReturn(new WorkContext());
 		Mockito.when(this.workFlowDefinitionRepository.findByName(Mockito.any()))
 				.thenReturn(List.of(this.sampleWorkflowDefinition("test")));
 
@@ -190,8 +188,8 @@ class WorkFlowServiceImplTest {
 				.workFlowExecutionId(wfExecutionID).build();
 		workFlowTaskExecution.setId(UUID.randomUUID());
 
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID, wfTaskDefID))
-				.thenReturn(List.of(workFlowTaskExecution));
+		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
+				wfTaskDefID)).thenReturn(List.of(workFlowTaskExecution));
 		// when
 
 		WorkFlowTaskExecution res = this.workFlowService.getWorkFlowTask(wfExecutionID, wfTaskDefID);
@@ -210,8 +208,8 @@ class WorkFlowServiceImplTest {
 		// given
 		UUID wfTaskDefID = UUID.randomUUID();
 		UUID wfExecutionID = UUID.randomUUID();
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID, wfTaskDefID))
-				.thenReturn(null);
+		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
+				wfTaskDefID)).thenReturn(null);
 
 		// when
 		WorkFlowTaskExecution res = this.workFlowService.getWorkFlowTask(wfExecutionID, wfTaskDefID);
@@ -226,8 +224,8 @@ class WorkFlowServiceImplTest {
 		// given
 		UUID wfTaskDefID = UUID.randomUUID();
 		UUID wfExecutionID = UUID.randomUUID();
-		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID, wfTaskDefID))
-				.thenReturn(new LinkedList<>());
+		Mockito.when(this.workFlowTaskRepository.findByWorkFlowExecutionIdAndWorkFlowTaskDefinitionId(wfExecutionID,
+				wfTaskDefID)).thenReturn(new LinkedList<>());
 
 		// when
 		WorkFlowTaskExecution res = this.workFlowService.getWorkFlowTask(wfExecutionID, wfTaskDefID);


### PR DESCRIPTION
Due to the use of pull_request_target, the github_sha variable is always the base branch one, and in the commit
469fac8a1accbf3a7090e9b0fc9206d50058dd75, we should check out to the PR branch instead of the base branch.

This is because an external contributor can leak a write token, so for that, I took the following steps:

- By default, the GIHUB_TOKEN is always read (As normal)
- On the coverage plugin, the token has access to write checks only.

So, in case of anyone want to leak the token, it's only read-only as any normal PR. In the case of changing the actions themselves, it does not matter because it is using the base branch.

Also, fix an issue with the format in the java code, to pass the test.