### PR TITLE
Fix README files typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ progress).
 https://github.com/janus-idp
 
 The focus of Parodos is around Workflows (composed of WorkflowTasks) that bring together the existing tools and
-processes of the enterpise in an end-to-end experience that developers, quality assurance, produnction support and other
+processes of the enterpise in an end-to-end experience that developers, quality assurance, production support and other
 enterprise software development/delivery team members can consume (through our Backstage plugins or by your own
-interfaces calling these backing services) to get the outcomes they need with less tickets/meetings/frustration.
+interfaces calling these backing services) to get the outcomes they need with fewer tickets/meetings/frustration.
 
 # Building Developer Platforms In Enterprise Environments
 
 Building an IDP provides a centralized place to improve the experience for developers trying to build and release code
 in large environments.
 
-For many enterprise environments, especially regulated ones, the source of some of the friction preventing a positive
-developer experience is that they are entangled with long standing processes and tools which are tied to audit,
+For many enterprise environments, especially regulated ones, the source of some friction preventing a positive
+developer experience is that they are entangled with long-standing processes and tools which are tied to audit,
 compliance and regulation. These components are often:
 
 - Unique to the enterprise
@@ -49,14 +49,14 @@ Some enterprises may struggle with Javascript heavy approaches. That is not to s
 platforms are not suited for the task. On the contrary they might be just what is needed, but a chasm might exist to
 fully adopt in an enterprise environment that has legacy technology and processes.
 
-Other enterprises might have existing IDP tools that are home grown over years and might need to be leveraged in the
+Other enterprises might have existing IDP tools that are home-grown over years and might need to be leveraged in the
 initial stages of any new IDP work.
 
 Parodos is ancient Greek and translates to 'a side-entrance to the stage'. In this theme, Parodos provides Java based
 building blocks (specifically Spring beans) to bring together backend processes and components that might be considered
 more 'legacy' as workflows (including existing IDP components) that can be consumed in Backstage.
 
-The most common usecase for Parodos is giving developers a place where they can provide inputs for Assessments (ie: a
+The most common use case for Parodos is giving developers a place where they can provide inputs for Assessments (ie: a
 link to their project code and/or an application identifying code), and based on logic determined by the enterprise a
 list of Workflows are presented to them.
 
@@ -98,24 +98,24 @@ Parodos is composed of the following components
 
 **workflow-service**
 
-Provides the APIs to run Workflows defined usinmg the Parodos model. It also persists Workflow definitions (and tracks
-changes of definitions), persists execution state and provides scheduling for long running WorkFlowTasks.
+Provides the APIs to run Workflows defined using the Parodos model. It also persists Workflow definitions (and tracks
+changes of definitions), persists execution state and provides scheduling for long-running WorkFlowTasks.
 
 **parodos-model-api**
 
 This is the model used by all services. It also contains some abstract definition of WorkflowTask for specific use
 cases (ie: Assessment, checking a downstream approval). At present all Workflows and WorkflowTasks are define as Spring
-Framework beans. More information can be found the the READ of the workflow-service, parodos-model-api and
+Framework beans. More information can be found the READ of the workflow-service, parodos-model-api and 
 workflow-examples.
 
 **workflow-examples**
 
-A stand alone project that can be added to the workflow-service's classpath to provide some samples of what WorkFlows
+A standalone project that can be added to the workflow-service's classpath to provide some samples of what WorkFlows
 could look like. This is basically a 'Hello Wold' for the workflow-service
 
 **workflow-engine**
 
-The current library for exeucting WorkFlow(s) in Parodos service
+The current library for executing WorkFlow(s) in Parodos service
 
 **notification-service**
 
@@ -164,7 +164,7 @@ via the Parodos backing services
 
 ### Backing Services Only
 
-In the event that an environment is chosing to enhancing an existing IDP, or create their own, Parodos's Java APIs can
+In the event that an environment is choosing to enhancing an existing IDP, or create their own, Parodos's Java APIs can
 be used to provide backing Workflows. 
 
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,34 @@
 # What Is Parodos?
 
-Parodos is a Java toolkit to help enterprise's with a legacy footprint build internal developer platforms (IDP) that enable their developers to get access to the tools and environments required to start coding with less time, friction and frustration.
+Parodos is a Java toolkit to help enterprise's with a legacy footprint build internal developer platforms (IDP) that
+enable their developers to get access to the tools and environments required to start coding with less time, friction
+and frustration.
 
-This repository contains the backing services for Parodos. The user interface for Parodos are Backstage (https://backstage.io/) plugins that will be contributed to Red Hat's Janus-IDP initiative (this work is in progress).
+This repository contains the backing services for Parodos. The user interface for Parodos are
+Backstage (https://backstage.io/) plugins that will be contributed to Red Hat's Janus-IDP initiative (this work is in
+progress).
 https://github.com/janus-idp
 
-The focus of Parodos is around Workflows (composed of WorkflowTasks) that bring together the existing tools and processes of the enterpise in an end-to-end experience that developers, quality assurance, produnction support and other enterprise software development/delivery team members can consume (through our Backstage plugins or by your own interfaces calling these backing services) to get the outcomes they need with less tickets/meetings/frustration.
-
+The focus of Parodos is around Workflows (composed of WorkflowTasks) that bring together the existing tools and
+processes of the enterpise in an end-to-end experience that developers, quality assurance, produnction support and other
+enterprise software development/delivery team members can consume (through our Backstage plugins or by your own
+interfaces calling these backing services) to get the outcomes they need with less tickets/meetings/frustration.
 
 # Building Developer Platforms In Enterprise Environments
 
-Building an IDP provides a centralized place to improve the experience for developers trying to build and release code in large environments. 
+Building an IDP provides a centralized place to improve the experience for developers trying to build and release code
+in large environments.
 
-For many enterprise environments, especially regulated ones, the source of some of the friction preventing a positive developer experience is that they are entangled with long standing processes and tools which are tied to audit, compliance and regulation. These components are often:
+For many enterprise environments, especially regulated ones, the source of some of the friction preventing a positive
+developer experience is that they are entangled with long standing processes and tools which are tied to audit,
+compliance and regulation. These components are often:
 
 - Unique to the enterprise
 - Providing a necessary safeguard
 - Difficult to change or remove
 
-For more thoughts and opinions on the challenges in making changes to an existing software culture in an enterprise environment, please review the following blog: 
+For more thoughts and opinions on the challenges in making changes to an existing software culture in an enterprise
+environment, please review the following blog:
 
 https://www.redhat.com/en/blog/modernization-why-is-it-hard
 
@@ -26,19 +36,29 @@ For more information about building IDPs in regulated enterprise environments, r
 
 https://www.redhat.com/en/blog/considerations-when-implementing-developer-portals-regulated-enterprise-environments
 
-Parodos is focused on building solutions based on technical stacks that are both familiar, and have a history of success for enterprises described in the preceding articles.
+Parodos is focused on building solutions based on technical stacks that are both familiar, and have a history of success
+for enterprises described in the preceding articles.
 
 # The Focus Of Parodos
 
-Although frameworks and ecosystems might exist to help build developer portals, getting some of these approved for production use in certain enterprises, especially if they have a large ecosystem written by disparate developers, might be difficult. 
+Although frameworks and ecosystems might exist to help build developer portals, getting some of these approved for
+production use in certain enterprises, especially if they have a large ecosystem written by disparate developers, might
+be difficult.
 
-Some enterprises may struggle with Javascript heavy approaches. That is not to say such libraries, frameworks and platforms are not suited for the task. On the contrary they might be just what is needed, but a chasm might exist to fully adopt in an enterprise environment that has legacy technology and processes.
+Some enterprises may struggle with Javascript heavy approaches. That is not to say such libraries, frameworks and
+platforms are not suited for the task. On the contrary they might be just what is needed, but a chasm might exist to
+fully adopt in an enterprise environment that has legacy technology and processes.
 
-Other enterprises might have existing IDP tools that are home grown over years and might need to be leveraged in the initial stages of any new IDP work.
+Other enterprises might have existing IDP tools that are home grown over years and might need to be leveraged in the
+initial stages of any new IDP work.
 
-Parodos is ancient Greek and translates to 'a side-entrance to the stage'. In this theme, Parodos provides Java based building blocks (specifically Spring beans) to bring together backend processes and components that might be considered more 'legacy' as workflows (including existing IDP components) that can be consumed in Backstage.
+Parodos is ancient Greek and translates to 'a side-entrance to the stage'. In this theme, Parodos provides Java based
+building blocks (specifically Spring beans) to bring together backend processes and components that might be considered
+more 'legacy' as workflows (including existing IDP components) that can be consumed in Backstage.
 
-The most common usecase for Parodos is giving developers a place where they can provide inputs for Assessments (ie: a link to their project code and/or an application identifying code), and based on logic determined by the enterprise a list of Workflows are presented to them.
+The most common usecase for Parodos is giving developers a place where they can provide inputs for Assessments (ie: a
+link to their project code and/or an application identifying code), and based on logic determined by the enterprise a
+list of Workflows are presented to them.
 
 Examples might be:
 
@@ -48,23 +68,29 @@ Examples might be:
 - Add/Remove developers to a project
 - Change properties of an environment (ie: add more memory to QA)
 
-Developers will be presented with simple Wizard based steppers that collect information as needed and update them of any back-end approvals that are kicked off during the workflow which might result in a pause in the workflow. 
+Developers will be presented with simple Wizard based steppers that collect information as needed and update them of any
+back-end approvals that are kicked off during the workflow which might result in a pause in the workflow.
 
-In the backend Parodos will be calling the exact tooling to create enterprises approved blueprints for that specific use case.
+In the backend Parodos will be calling the exact tooling to create enterprises approved blueprints for that specific use
+case.
 
-All the logic of Parodos can be maintained in a seperate Java project using Spring beans as a means of creating and configuring workflows (future versions of Parodos will support other means of configuration).
+All the logic of Parodos can be maintained in a seperate Java project using Spring beans as a means of creating and
+configuring workflows (future versions of Parodos will support other means of configuration).
 
 # Who Is Parodos For?
 
 The following describes who would benefit the most from Parodos:
 
-1. Enterprises that are struggling logistically (or technically due to challenges hiring in a specific technology stack) Javascript heavy products in the developer portal space
+1. Enterprises that are struggling logistically (or technically due to challenges hiring in a specific technology stack)
+   Javascript heavy products in the developer portal space
 
 2. Teams that are comfortable building and operating a custom Java based application
 
-3. Environments where there are existing tools for building, deploying and observing application that can be integrated with
+3. Environments where there are existing tools for building, deploying and observing application that can be integrated
+   with
 
-If all of these exist, your enterprise may benefit from using Parodos to build some workflows to help developers deliver code faster.
+If all of these exist, your enterprise may benefit from using Parodos to build some workflows to help developers deliver
+code faster.
 
 ## Parodos Components
 
@@ -72,15 +98,20 @@ Parodos is composed of the following components
 
 **workflow-service**
 
-Provides the APIs to run Workflows defined usinmg the Parodos model. It also persists Workflow definitions (and tracks changes of definitions), persists execution state and provides scheduling for long running WorkFlowTasks.
+Provides the APIs to run Workflows defined usinmg the Parodos model. It also persists Workflow definitions (and tracks
+changes of definitions), persists execution state and provides scheduling for long running WorkFlowTasks.
 
 **parodos-model-api**
 
-This is the model used by all services. It also contains some abstract definition of WorkflowTask for specific use cases (ie: Assessment, checking a downstream approval). At present all Workflows and WorkflowTasks are define as Spring Framework beans. More information can be found the the READ of the workflow-service, parodos-model-api and workflow-examples.
+This is the model used by all services. It also contains some abstract definition of WorkflowTask for specific use
+cases (ie: Assessment, checking a downstream approval). At present all Workflows and WorkflowTasks are define as Spring
+Framework beans. More information can be found the the READ of the workflow-service, parodos-model-api and
+workflow-examples.
 
 **workflow-examples**
 
-A stand alone project that can be added to the workflow-service's classpath to provide some samples of what WorkFlows could look like. This is basically a 'Hello Wold' for the workflow-service
+A stand alone project that can be added to the workflow-service's classpath to provide some samples of what WorkFlows
+could look like. This is basically a 'Hello Wold' for the workflow-service
 
 **workflow-engine**
 
@@ -88,16 +119,20 @@ The current library for exeucting WorkFlow(s) in Parodos service
 
 **notification-service**
 
-Simple API for posting read-only messages related to downstream processes. The Parodos Backstage plugins provide a UI to display these messages. This service might be useful for those team members who might not have access to other commonly used communication systems (like Slack). It also provides a means of providing the users with updates in the same interface where the workflow is being executed
+Simple API for posting read-only messages related to downstream processes. The Parodos Backstage plugins provide a UI to
+display these messages. This service might be useful for those team members who might not have access to other commonly
+used communication systems (like Slack). It also provides a means of providing the users with updates in the same
+interface where the workflow is being executed
 
 **pattern-detection-library**
 
-A java library that can be used in AssessmentTasks to identify application/configuration patterns that can be associated with specific workflows (ie: Batch applications might have a different pipeline and environments than a .NET based MVC application).
+A java library that can be used in AssessmentTasks to identify application/configuration patterns that can be associated
+with specific workflows (ie: Batch applications might have a different pipeline and environments than a .NET based MVC
+application).
 
 For more information on each of these, please review the README location in the root folder of each component.
 
 Stay tuned to this repository as more Parodos components will be added in the coming weeks.
-
 
 ## Building the Code
 
@@ -109,20 +144,27 @@ mvn clean install
 
 ```
 
-This will build the dependencies and install them into your local mvn directory. This last part is important as the Parodos 'workflow-engine' is not in Maven Central. If you wish to use it in a project like the workflow-examples, you will need to build it locally first.
+This will build the dependencies and install them into your local mvn directory. This last part is important as the
+Parodos 'workflow-engine' is not in Maven Central. If you wish to use it in a project like the workflow-examples, you
+will need to build it locally first.
 
 ## Is Parodos an Application?
 
-Parodos provides an API and object model that can be used as a backing service for an IDP. If Backstage is in use, the Parodos Janus-IDP plugins can be used to provide a user experience to teams. If the enterprise has chosen to build their own IDP, or have an existing custom IDP they wish to enhance, the Parodos backing services can be consumed directly.
+Parodos provides an API and object model that can be used as a backing service for an IDP. If Backstage is in use, the
+Parodos Janus-IDP plugins can be used to provide a user experience to teams. If the enterprise has chosen to build their
+own IDP, or have an existing custom IDP they wish to enhance, the Parodos backing services can be consumed directly.
 
 ## Deployment Models
 
 ### Backstage Plugin
 
-In this model the Parodos backing APIs are deployed in the enterprise environment along with Backstage where the Parodos plugins are deployed. Users interact with the plugins via Backstage, the plugins maintain state and call backend systems via the Parodos backing services
+In this model the Parodos backing APIs are deployed in the enterprise environment along with Backstage where the Parodos
+plugins are deployed. Users interact with the plugins via Backstage, the plugins maintain state and call backend systems
+via the Parodos backing services
 
 ### Backing Services Only
 
-In the event that an environment is chosing to enhancing an existing IDP, or create their own, Parodos's Java APIs can be used to provide backing Workflows. 
+In the event that an environment is chosing to enhancing an existing IDP, or create their own, Parodos's Java APIs can
+be used to provide backing Workflows. 
 
 

--- a/notification-service/README.md
+++ b/notification-service/README.md
@@ -17,14 +17,14 @@ The service is based on the following Entities:
 * NotificationUser - Contains metadata about a User as well as a List of NotificationGroup(s) the User is associated
   with
 
-* NotificationGroup - Contains meta data about the group and list of a Users associated with it
+* NotificationGroup - Contains metadata about the group and list of a Users associated with it
 
 ## Services and Controllers
 
 Each Domain entity has an associated Service and ServiceImpl for performing CRUD operations.
 
 The **NotificationMessageController** provides a single endpoint for creating NotificationMessages. This is the endpoint
-that downstream services/systems can POST too.
+that downstream services/systems can POST to.
 
 The **NotificationRecordController** provides both GET endpoints (for obtaining NotificationMessages) and PUT endpoints
 for updating their metadata (ie: message has been read).

--- a/notification-service/README.md
+++ b/notification-service/README.md
@@ -1,16 +1,21 @@
 # Parodos Notification Service
 
-This service is intended to provide an Endpoint to receive messages from downstream services/systems providing the users with details/feedback related to workflow/tasks Parodos is orchestrating for them. This service works with the Parodos Notification UI workflow (can be deployed stand alone or with a Backstage plugin).
+This service is intended to provide an Endpoint to receive messages from downstream services/systems providing the users
+with details/feedback related to workflow/tasks Parodos is orchestrating for them. This service works with the Parodos
+Notification UI workflow (can be deployed stand alone or with a Backstage plugin).
 
 ## Domain Model
 
 The service is based on the following Entities:
 
-* NotificationsMessage - Contains metadata related to the Notification, target UserID(s) as well as a NotificationRecord reference
+* NotificationsMessage - Contains metadata related to the Notification, target UserID(s) as well as a NotificationRecord
+  reference
 
-* NotificationRecord - Contains metadata around how the UI/User has interacted with the Notification (ie: Read it), contains  a List of Notification Users
+* NotificationRecord - Contains metadata around how the UI/User has interacted with the Notification (ie: Read it),
+  contains a List of Notification Users
 
-* NotificationUser - Contains metadata about a User as well as a List of NotificationGroup(s) the User is associated with
+* NotificationUser - Contains metadata about a User as well as a List of NotificationGroup(s) the User is associated
+  with
 
 * NotificationGroup - Contains meta data about the group and list of a Users associated with it
 
@@ -18,9 +23,11 @@ The service is based on the following Entities:
 
 Each Domain entity has an associated Service and ServiceImpl for performing CRUD operations.
 
-The **NotificationMessageController** provides a single endpoint for creating NotificationMessages. This is the endpoint that downstream services/systems can POST too.
+The **NotificationMessageController** provides a single endpoint for creating NotificationMessages. This is the endpoint
+that downstream services/systems can POST too.
 
-The **NotificationRecordController** provides both GET endpoints (for obtaining NotificationMessages) and PUT endpoints for updating their metadata (ie: message has been read).
+The **NotificationRecordController** provides both GET endpoints (for obtaining NotificationMessages) and PUT endpoints
+for updating their metadata (ie: message has been read).
 
 ## Persistence
 
@@ -28,10 +35,14 @@ The service uses JPA to persist. Postgres is the recommended DB. For the 'dev' p
 
 ## User Interface
 
-The UI for this service can be found as a backstage Plugin for a stand-alone Java service (UI + API) in one Jar, check out implementation-examples/java-services
+The UI for this service can be found as a backstage Plugin for a stand-alone Java service (UI + API) in one Jar, check
+out implementation-examples/java-services
 
 ## FAQ
 
 ### We use Slack, is this required?
 
-This feature is an optional component of Parodos. If there is another application (ie: Slack) you prefer to provide updates to user on, feel free to integration Parodos's WorkFlows to that. However, keep in mind that some personas in your environment might not have access to these tools, or experience a long delay to get access. As a result, this notification flow might be interesting to some users
+This feature is an optional component of Parodos. If there is another application (ie: Slack) you prefer to provide
+updates to user on, feel free to integration Parodos's WorkFlows to that. However, keep in mind that some personas in
+your environment might not have access to these tools, or experience a long delay to get access. As a result, this
+notification flow might be interesting to some users

--- a/parodos-model-api/README.md
+++ b/parodos-model-api/README.md
@@ -6,7 +6,7 @@ The goal of Parodos is to provide Java based Workflows that blend modern automat
 
 This project contains all the dependencies to create and configure Parodos Workflows. 
 
-The goal of a Workflow is to achieve an outcome for a developer. For example,the OCP onboarding Workflow might perform all the steps to set up tooling, environment but also permissions, networking and required monitoring and security tooling. After running this Workflow, not only can add developer build, deploy and test in lower level environments, but they also have an easier path to get to production with their code.
+The goal of a Workflow is to achieve an outcome for a developer. For example, the OCP onboarding Workflow might perform all the steps to set up tooling, environment but also permissions, networking and required monitoring and security tooling. After running this Workflow, not only can add developer build, deploy and test in lower level environments, but they also have an easier path to get to production with their code.
 
 Parodos Workflows are composed of Parodos WorkflowTasks. These perform the necessary steps in the Workflow to achieve the desired outcome. How many WorkflowTasks (steps) are required to achieve an outcome will vary across environments.
 
@@ -52,13 +52,13 @@ After a successful build the libraries can be added to a Java project by adding 
 
 ## Concepts and Example Usage
 
-The foundation of Parodos is the Workflow object (see the workflow-engine folder of this project for more details about Workflows). Workflows are Composed of WorkflowTasks. WorkflowTasks do the work of the Workflow. A WorkContext is shared throughout the Workflow's execution. This provides a means of passing information into the Workflow before execution, but also a means of collecting information created during the execution. A WorkReport is returned at the end of an execution for a Workflow that provides an indication of the final outcome of the Workflow and the final state of the WorkContext. Workflows are consumed by the workflow-service where additional functionality around persistence and execution is made available.
+The foundation of Parodos is the Workflow object (see the workflow-engine folder of this project for more details about Workflows). Workflows are composed of WorkflowTasks. WorkflowTasks do the work of the Workflow. A WorkContext is shared throughout the Workflow's execution. This provides a means of passing information into the Workflow before execution, but also a means of collecting information created during the execution. A WorkReport is returned at the end of an execution for a Workflow that provides an indication of the final outcome of the Workflow and the final state of the WorkContext. Workflows are consumed by the workflow-service where additional functionality around persistence and execution is made available.
 
 
 ![UML](readme-images/basic-objects.png)
 
 
-In Parodos there are a few specified Workflows that are common in the IDP space.  They can be found in the WorkFlowType enum. At present these are:
+In Parodos there are a few specified Workflows that are common in the IDP space.  They can be found in the `WorkFlowType` enum. At present these are:
 
 - Assessment (takes inputs and gives a list of Workflow options for a user to choose from)
 - Checker (determines the status of a manual process that is blocking other Workflows from running)
@@ -89,9 +89,9 @@ WorkflowTask objects do work (as defined in the execute method) and are placed i
 
 ** BaseAssessmentTask ** - these WorkflowTasks accepts a collection of inputs, and returns WorkflowOptions based on custom logic that can be defined in the task. These tasks are intended to be used in Workflows to help developers (and other team members) determine what Workflows they can run for their use case. For example, an assessment might review code looking for a pipeline definition or the presence of a certain 3rd party service - both of which would imply different workflows.
 
-** BaseWorkFlowTask ** - these WorkflowTasks are intended to call downstream systems that initiate automation. The class can optionally can reference a WorkflowChecker workflow
+** BaseWorkFlowTask ** - these WorkflowTasks are intended to call downstream systems that initiate automation. The class can optionally reference a WorkflowChecker workflow
 
-** WorkFlowCheckerTask ** - Checks the status of manual processes triggered by other Workflows. WorkFlowCheckerTasks can be long running when place into a WorkFlow when the definition of the Workflow its contained inside is of type WorkFlowCheckerDefinition (the workflow-service provides scheduling for these tasks) and its outcomes 
+** WorkFlowCheckerTask ** - Checks the status of manual processes triggered by other Workflows. WorkFlowCheckerTasks can be long-running when placed into a WorkFlow when the definition of the Workflow it's contained inside the type WorkFlowCheckerDefinition (the workflow-service provides scheduling for these tasks) and its outcomes.
 
 The following is an example of a WorkflowTask being defined.
 
@@ -163,7 +163,7 @@ There are:
 - Checker
 - Infrastructure
 
-The annotations provide a means of configuring the Workflow and also indicating to the workflow-service these specific types of Workflows so it can provide the related functionality for these Workflows (ie: Checker workflows can be scheduled to execute based on a cron expression specific in the Checker annotation).
+The annotations provide a means of configuring the Workflow and also indicating to the workflow-service these specific types of Workflows, so it can provide the related functionality for these Workflows (ie: Checker workflows can be scheduled to execute based on a cron expression specific in the Checker annotation).
 
 Here is an example of a Workflow bean being created (and the WorkflowTask it uses), and a Workflow annotation being used:
 
@@ -190,7 +190,7 @@ Here is an example of a Workflow bean being created (and the WorkflowTask it use
 
 ### Describing Workflows To Users
 
-** WorkFlowOption ** - a description of a Workflow that can be presented to a user as a potential Workflow to execute. These can be created using a building in a methond returning a Bean.
+** WorkFlowOption ** - a description of a Workflow that can be presented to a user as a potential Workflow to execute. These can be created using a building method returning a Bean.
 
 ```java
 
@@ -261,10 +261,10 @@ This project also specifies definition classes, which are required for versionin
 
 ## Using This API with the Workflow Service
 
-Provided all the code was created in following the standards outlined , simply generate a Jar file and place this in the classpath of the Infrastructure Service. Upon start up it will register the configured Task(s) and WorkFlow(s). Its key that 
+Provided all the code was created in following the standards outlined, simply generate a Jar file and place this in the classpath of the Infrastructure Service. Upon start up it will register the configured Task(s) and WorkFlow(s).
 
-Future versions of Parodos will include other options for creating and registering WorkFlowTasks and WorkFlows
+Future versions of Parodos will include other options for creating and registering WorkFlowTasks and WorkFlows.
 
 ## Demo Implementation
 
-For a full example show how to configure all these Task(s) and WorkFlows(s), please refer to the 'workflow-examples'
+For a full example show how to configure all these Task(s) and WorkFlows(s), please refer to the 'workflow-examples'.

--- a/parodos-model-api/README.md
+++ b/parodos-model-api/README.md
@@ -2,35 +2,50 @@
 
 ## Introduction
 
-The goal of Parodos is to provide Java based Workflows that blend modern automation tooling with integrations and insight into legacy (and even manual) processes to provide developers everything they need to start quickly and effectively coding and deploying their code in their unique environment.
+The goal of Parodos is to provide Java based Workflows that blend modern automation tooling with integrations and
+insight into legacy (and even manual) processes to provide developers everything they need to start quickly and
+effectively coding and deploying their code in their unique environment.
 
-This project contains all the dependencies to create and configure Parodos Workflows. 
+This project contains all the dependencies to create and configure Parodos Workflows.
 
-The goal of a Workflow is to achieve an outcome for a developer. For example, the OCP onboarding Workflow might perform all the steps to set up tooling, environment but also permissions, networking and required monitoring and security tooling. After running this Workflow, not only can add developer build, deploy and test in lower level environments, but they also have an easier path to get to production with their code.
+The goal of a Workflow is to achieve an outcome for a developer. For example, the OCP onboarding Workflow might perform
+all the steps to set up tooling, environment but also permissions, networking and required monitoring and security
+tooling. After running this Workflow, not only can add developer build, deploy and test in lower level environments, but
+they also have an easier path to get to production with their code.
 
-Parodos Workflows are composed of Parodos WorkflowTasks. These perform the necessary steps in the Workflow to achieve the desired outcome. How many WorkflowTasks (steps) are required to achieve an outcome will vary across environments.
+Parodos Workflows are composed of Parodos WorkflowTasks. These perform the necessary steps in the Workflow to achieve
+the desired outcome. How many WorkflowTasks (steps) are required to achieve an outcome will vary across environments.
 
 Parodos Workflows can be executed by the Parodos workflow-service.
 
-This is a high level view of a complete Workflow and WorkflowTasks, running in the workflow-service (this also shows how the notification-service) interacting with a tooling and process in a legacy environment to get a developer set up to work.
+This is a high level view of a complete Workflow and WorkflowTasks, running in the workflow-service (this also shows how
+the notification-service) interacting with a tooling and process in a legacy environment to get a developer set up to
+work.
 
 ![UML](readme-images/complete-workflow-outcomes.png)
 
-The README of the workflow-example folder in this project will provide an overview of what a Parodos Workflow/WorkflowTask configuration can look like.
+The README of the workflow-example folder in this project will provide an overview of what a Parodos
+Workflow/WorkflowTask configuration can look like.
 
-Developers/Quality Assurance/Application Support and any other member of a software delivery can consume Parodos workflows via a Backstage plugins (https://github.com/janus-idp/backstage-plugins), or using the Parodos backing APIs integrated with another interface developed by the enterprise.
+Developers/Quality Assurance/Application Support and any other member of a software delivery can consume Parodos
+workflows via a Backstage plugins (https://github.com/janus-idp/backstage-plugins), or using the Parodos backing APIs
+integrated with another interface developed by the enterprise.
 
-The IDP internal development team build Workflows and their composing WorkflowTasks in partnership with infrastructure operations/networking/audit/security/DevOps (any team in the enterprise owning/operating/governing tools and environment) using this API.
+The IDP internal development team build Workflows and their composing WorkflowTasks in partnership with infrastructure
+operations/networking/audit/security/DevOps (any team in the enterprise owning/operating/governing tools and
+environment) using this API.
 
 The following is a UML diagram of the current Parodos Object Model.
 
 ![UML](readme-images/uml.png)
 
-This document will provide more details around how to use the Parodos model to created Worksflow that can be executed by the Parodos workflow-service.
+This document will provide more details around how to use the Parodos model to created Worksflow that can be executed by
+the Parodos workflow-service.
 
 ## Building The Code
 
-The source for this package is in the Parodos repo. Use the **parent** pom.xml at the **root of the project** to build and install it into your local maven repo.
+The source for this package is in the Parodos repo. Use the **parent** pom.xml at the **root of the project** to build
+and install it into your local maven repo.
 
 ```shell
 
@@ -52,13 +67,18 @@ After a successful build the libraries can be added to a Java project by adding 
 
 ## Concepts and Example Usage
 
-The foundation of Parodos is the Workflow object (see the workflow-engine folder of this project for more details about Workflows). Workflows are composed of WorkflowTasks. WorkflowTasks do the work of the Workflow. A WorkContext is shared throughout the Workflow's execution. This provides a means of passing information into the Workflow before execution, but also a means of collecting information created during the execution. A WorkReport is returned at the end of an execution for a Workflow that provides an indication of the final outcome of the Workflow and the final state of the WorkContext. Workflows are consumed by the workflow-service where additional functionality around persistence and execution is made available.
-
+The foundation of Parodos is the Workflow object (see the workflow-engine folder of this project for more details about
+Workflows). Workflows are composed of WorkflowTasks. WorkflowTasks do the work of the Workflow. A WorkContext is shared
+throughout the Workflow's execution. This provides a means of passing information into the Workflow before execution,
+but also a means of collecting information created during the execution. A WorkReport is returned at the end of an
+execution for a Workflow that provides an indication of the final outcome of the Workflow and the final state of the
+WorkContext. Workflows are consumed by the workflow-service where additional functionality around persistence and
+execution is made available.
 
 ![UML](readme-images/basic-objects.png)
 
-
-In Parodos there are a few specified Workflows that are common in the IDP space.  They can be found in the `WorkFlowType` enum. At present these are:
+In Parodos there are a few specified Workflows that are common in the IDP space. They can be found in the `WorkFlowType`
+enum. At present these are:
 
 - Assessment (takes inputs and gives a list of Workflow options for a user to choose from)
 - Checker (determines the status of a manual process that is blocking other Workflows from running)
@@ -75,23 +95,35 @@ Executions of the WorkflowTasks (which is done by the Workflow object) can be do
 - Predicate
 - Repeating
 
-At present the Parodos Workflow engine wraps the Easy Flows project (https://github.com/j-easy/easy-flows). Future releases of Parodos may provide options to leverage other Workflow engines. For this first version of Parodos, easy-flows provides all the necessary functionality.
+At present the Parodos Workflow engine wraps the Easy Flows project (https://github.com/j-easy/easy-flows). Future
+releases of Parodos may provide options to leverage other Workflow engines. For this first version of Parodos,
+easy-flows provides all the necessary functionality.
 
 The following is a brief overview of the object model.
 
 ## Object Overview
 
-The following is a quick description of the important objects and base types in this project. All of these objects are intended to be created (and configured) using Spring beans.
+The following is a quick description of the important objects and base types in this project. All of these objects are
+intended to be created (and configured) using Spring beans.
 
 ### Parodos WorkflowTask
 
-WorkflowTask objects do work (as defined in the execute method) and are placed in a Workflow object where they will be executed when the Workflow itself is executed. Parodos provides to structure around the types of tasks with some abstract implementations. These are useful implementations for an IDP.
+WorkflowTask objects do work (as defined in the execute method) and are placed in a Workflow object where they will be
+executed when the Workflow itself is executed. Parodos provides to structure around the types of tasks with some
+abstract implementations. These are useful implementations for an IDP.
 
-** BaseAssessmentTask ** - these WorkflowTasks accepts a collection of inputs, and returns WorkflowOptions based on custom logic that can be defined in the task. These tasks are intended to be used in Workflows to help developers (and other team members) determine what Workflows they can run for their use case. For example, an assessment might review code looking for a pipeline definition or the presence of a certain 3rd party service - both of which would imply different workflows.
+** BaseAssessmentTask ** - these WorkflowTasks accepts a collection of inputs, and returns WorkflowOptions based on
+custom logic that can be defined in the task. These tasks are intended to be used in Workflows to help developers (and
+other team members) determine what Workflows they can run for their use case. For example, an assessment might review
+code looking for a pipeline definition or the presence of a certain 3rd party service - both of which would imply
+different workflows.
 
-** BaseWorkFlowTask ** - these WorkflowTasks are intended to call downstream systems that initiate automation. The class can optionally reference a WorkflowChecker workflow
+** BaseWorkFlowTask ** - these WorkflowTasks are intended to call downstream systems that initiate automation. The class
+can optionally reference a WorkflowChecker workflow
 
-** WorkFlowCheckerTask ** - Checks the status of manual processes triggered by other Workflows. WorkFlowCheckerTasks can be long-running when placed into a WorkFlow when the definition of the Workflow it's contained inside the type WorkFlowCheckerDefinition (the workflow-service provides scheduling for these tasks) and its outcomes.
+** WorkFlowCheckerTask ** - Checks the status of manual processes triggered by other Workflows. WorkFlowCheckerTasks can
+be long-running when placed into a WorkFlow when the definition of the Workflow it's contained inside the type
+WorkFlowCheckerDefinition (the workflow-service provides scheduling for these tasks) and its outcomes.
 
 The following is an example of a WorkflowTask being defined.
 
@@ -152,7 +184,6 @@ public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 
 ```
 
-
 ### Workflow Definitions and Workflow Types
 
 The Parodos model provides some annotations that can be placed on a Bean creating a Workflow object.
@@ -163,9 +194,12 @@ There are:
 - Checker
 - Infrastructure
 
-The annotations provide a means of configuring the Workflow and also indicating to the workflow-service these specific types of Workflows, so it can provide the related functionality for these Workflows (ie: Checker workflows can be scheduled to execute based on a cron expression specific in the Checker annotation).
+The annotations provide a means of configuring the Workflow and also indicating to the workflow-service these specific
+types of Workflows, so it can provide the related functionality for these Workflows (ie: Checker workflows can be
+scheduled to execute based on a cron expression specific in the Checker annotation).
 
-Here is an example of a Workflow bean being created (and the WorkflowTask it uses), and a Workflow annotation being used:
+Here is an example of a Workflow bean being created (and the WorkflowTask it uses), and a Workflow annotation being
+used:
 
 ```java
 
@@ -190,7 +224,8 @@ Here is an example of a Workflow bean being created (and the WorkflowTask it use
 
 ### Describing Workflows To Users
 
-** WorkFlowOption ** - a description of a Workflow that can be presented to a user as a potential Workflow to execute. These can be created using a building method returning a Bean.
+** WorkFlowOption ** - a description of a Workflow that can be presented to a user as a potential Workflow to execute.
+These can be created using a building method returning a Bean.
 
 ```java
 
@@ -204,7 +239,10 @@ Here is an example of a Workflow bean being created (and the WorkflowTask it use
 
 ```
 
-** WorkFlowOptions ** - a collection of WorkFlow options grouped in a categories specific to IDP common workflows. These are upgrade, migrate, new (this is onboarding for the first time) and other (these are team related workflows like adding a new developer to a project). WorkflowOptions are created by an AssessmentTask. In a Workflow there might be many of these WorkflowTasks
+** WorkFlowOptions ** - a collection of WorkFlow options grouped in a categories specific to IDP common workflows. These
+are upgrade, migrate, new (this is onboarding for the first time) and other (these are team related workflows like
+adding a new developer to a project). WorkflowOptions are created by an AssessmentTask. In a Workflow there might be
+many of these WorkflowTasks
 
 Here is a sample of a AssessmentTasks.
 
@@ -247,8 +285,9 @@ public class OnboardingAssessmentTask extends BaseAssessmentTask {
 
 ```
 
-For a complete example of how to use this API, please refer to the 'workflow-example' project. To learn more about the workflow-service (the Parodos API that executes Workflows and maintains all relevant state), refer to the README of the workflow-service folder.
-
+For a complete example of how to use this API, please refer to the 'workflow-example' project. To learn more about the
+workflow-service (the Parodos API that executes Workflows and maintains all relevant state), refer to the README of the
+workflow-service folder.
 
 ### Delegates
 
@@ -258,10 +297,10 @@ The model includes some classes that contain useful logic related to creating an
 
 This project also specifies definition classes, which are required for versioning and for UI related functionality.
 
-
 ## Using This API with the Workflow Service
 
-Provided all the code was created in following the standards outlined, simply generate a Jar file and place this in the classpath of the Infrastructure Service. Upon start up it will register the configured Task(s) and WorkFlow(s).
+Provided all the code was created in following the standards outlined, simply generate a Jar file and place this in the
+classpath of the Infrastructure Service. Upon start up it will register the configured Task(s) and WorkFlow(s).
 
 Future versions of Parodos will include other options for creating and registering WorkFlowTasks and WorkFlows.
 

--- a/parodos-model-api/README.md
+++ b/parodos-model-api/README.md
@@ -77,15 +77,11 @@ Executions of the WorkflowTasks (which is done by the Workflow object) can be do
 
 At present the Parodos Workflow engine wraps the Easy Flows project (https://github.com/j-easy/easy-flows). Future releases of Parodos may provide options to leverage other Workflow engines. For this first version of Parodos, easy-flows provides all the necessary functionality.
 
-![UML](readme-images/assessment-workflow.png)
-
-
 The following is a brief overview of the object model.
 
 ## Object Overview
 
 The following is a quick description of the important objects and base types in this project. All of these objects are intended to be created (and configured) using Spring beans.
-
 
 ### Parodos WorkflowTask
 

--- a/pattern-detection-library/README.md
+++ b/pattern-detection-library/README.md
@@ -1,6 +1,8 @@
 # Pattern Detection Library
 
-This is a Java Library that can be used to detect different 'Patterns' in code/configuration that can be used during the Assessment phase of the Parodos infrastructure-service to help determine if a specific Infrastructure Option should be assigned (ie: .NET applications, Java and J2EE Java all have different options)
+This is a Java Library that can be used to detect different 'Patterns' in code/configuration that can be used during the
+Assessment phase of the Parodos infrastructure-service to help determine if a specific Infrastructure Option should be
+assigned (ie: .NET applications, Java and J2EE Java all have different options)
 
 ## Introduction
 
@@ -12,17 +14,18 @@ This library can be used by any Parodos Service, or Infrastructure workflow to d
 
 A combination of Clues that might be found in code base.
 
-A Pattern has a collection of needOneOfClues, and a collection of needAllOfClues. Provided the appropriate Clues are detected in these collection, the Pattern is considered to be detected.
+A Pattern has a collection of needOneOfClues, and a collection of needAllOfClues. Provided the appropriate Clues are
+detected in these collection, the Pattern is considered to be detected.
 
 A pattern can be programmatically configured like this:
 
 ```java
 
-BasicPatternImpl controllerMavenPattern = BasicPatternImpl.Builder
-				.aNewPattern()
-				.addThisToAllAreRequiredClues(mavenConfig)
-				.addThisToAllAreRequiredClues(reactConfig)
-				.build();
+BasicPatternImpl controllerMavenPattern=BasicPatternImpl.Builder
+        .aNewPattern()
+        .addThisToAllAreRequiredClues(mavenConfig)
+        .addThisToAllAreRequiredClues(reactConfig)
+        .build();
 ```
 
 **Clue**
@@ -31,7 +34,8 @@ A Clue is something specific that is being looked for in a file or collection of
 
 Implementations of Clues are:
 
-**FileContentsCondition** Looks for specific strings in a file. Support for Regex. Example: (Java file containing @RestController)
+**FileContentsCondition** Looks for specific strings in a file. Support for Regex. Example: (Java file containing
+@RestController)
 
 **FileExtensionCondition** Looks for files that contain a specific extension. Support for Regex. Example: (.js file)
 
@@ -44,38 +48,44 @@ A clue can be configured in Java like this:
 ```java
 
 ContentsClueImpl.Builder
-	.builder()
-	.name("restcontroller")
-	.targetFileExtensionPatternString(".java")
-	.targetContentPatternString("@RestController")
-	.build();
+        .builder()
+        .name("restcontroller")
+        .targetFileExtensionPatternString(".java")
+        .targetContentPatternString("@RestController")
+        .build();
 
 ```
 
-This clue looks for a .java file that contains the annotation '@RestController'. By default the engine will stop scanning for this Clue after it's been detected. However, the clue can be configured to continue to scan resulting in positive match and the list of all files that met the Clue criteria.
+This clue looks for a .java file that contains the annotation '@RestController'. By default the engine will stop
+scanning for this Clue after it's been detected. However, the clue can be configured to continue to scan resulting in
+positive match and the list of all files that met the Clue criteria.
 
 Another example, one that looks for a pom.xml looks like this:
 
 ```java
 
-NameClueImpl.Builder.builder().name("maven").targetFileNamePatternString("pom.xml").build();
-
+NameClueImpl.Builder
+        .builder()
+        .name("maven")
+        .targetFileNamePatternString("pom.xml")
+        .build();
 ```
-
 
 ## Detecting Patterns
 
-Once the Clues and Patterns have been defined, a detection can run on code or folders for one or more patterns like this:
+Once the Clues and Patterns have been defined, a detection can run on code or folders for one or more patterns like
+this:
 
 ```java
 
-WorkContext context = WorkContextDelegate.WorkContextBuilder.builder()
-				.startDirectory(new File(SRC_TEST_RESOURCES_JAVA_WEB_CONTROLLER_CLUE).getAbsolutePath())
-				.addThisToDesiredPatterns(controllerMavenPattern)
-				.build();
-		DetectionResults results = PatternDetector.detect(context);
+WorkContext context=WorkContextDelegate.WorkContextBuilder.builder()
+        .startDirectory(new File(SRC_TEST_RESOURCES_JAVA_WEB_CONTROLLER_CLUE).getAbsolutePath())
+        .addThisToDesiredPatterns(controllerMavenPattern)
+        .build();
+        DetectionResults results=PatternDetector.detect(context);
 
 ```
 
-The DectionResults object will contain the detected Patterns, start time (or the detection run), end time (of the detection run) and all discovered Clue (regardless of if they were part of a detected Pattern).
+The DectionResults object will contain the detected Patterns, start time (or the detection run), end time (of the
+detection run) and all discovered Clue (regardless of if they were part of a detected Pattern).
 

--- a/pattern-detection-library/README.md
+++ b/pattern-detection-library/README.md
@@ -12,10 +12,10 @@ This library can be used by any Parodos Service, or Infrastructure workflow to d
 
 **Pattern**
 
-A combination of Clues that might be found in code base.
+A combination of _Clues_ that might be found in code base.
 
-A Pattern has a collection of needOneOfClues, and a collection of needAllOfClues. Provided the appropriate Clues are
-detected in these collection, the Pattern is considered to be detected.
+A Pattern has a collection of `needOneOfClues`, and a collection of `needAllOfClues`. Provided the appropriate _Clues_
+are detected in these collection, the Pattern is considered to be detected.
 
 A pattern can be programmatically configured like this:
 
@@ -56,7 +56,7 @@ ContentsClueImpl.Builder
 
 ```
 
-This clue looks for a .java file that contains the annotation '@RestController'. By default the engine will stop
+This clue looks for a .java file that contains the annotation '@RestController'. By default, the engine will stop
 scanning for this Clue after it's been detected. However, the clue can be configured to continue to scan resulting in
 positive match and the list of all files that met the Clue criteria.
 
@@ -78,14 +78,13 @@ this:
 
 ```java
 
-WorkContext context=WorkContextDelegate.WorkContextBuilder.builder()
+WorkContext context = WorkContextDelegate.WorkContextBuilder.builder()
         .startDirectory(new File(SRC_TEST_RESOURCES_JAVA_WEB_CONTROLLER_CLUE).getAbsolutePath())
         .addThisToDesiredPatterns(controllerMavenPattern)
         .build();
-        DetectionResults results=PatternDetector.detect(context);
-
+        DetectionResults results = PatternDetector.detect(context);
 ```
 
-The DectionResults object will contain the detected Patterns, start time (or the detection run), end time (of the
+The `DectionResults` object will contain the detected Patterns, start time (or the detection run), end time (of the
 detection run) and all discovered Clue (regardless of if they were part of a detected Pattern).
 

--- a/workflow-engine/README.md
+++ b/workflow-engine/README.md
@@ -1,17 +1,27 @@
 # Parodos Workflow Engine
 
-Parodos sits on top of existing tools and process in an enterprise environment. As a result, its assumed there will be existing workflow tool and business rules engine. However, within Parodos itself there is a need to execute tasks asynchronously while collecting their results.
+Parodos sits on top of existing tools and process in an enterprise environment. As a result, its assumed there will be
+existing workflow tool and business rules engine. However, within Parodos itself there is a need to execute tasks
+asynchronously while collecting their results.
 
-There are existing Workflow engines in Java, but many to be very complex (BPMN implementations), and as previously its assumed where Parodos is running there will will most likely be such engines/frameworks. As a result Parodos's current implementation for internally executing Workflows is https://github.com/j-easy/easy-flows.
+There are existing Workflow engines in Java, but many to be very complex (BPMN implementations), and as previously its
+assumed where Parodos is running there will will most likely be such engines/frameworks. As a result Parodos's current
+implementation for internally executing Workflows is https://github.com/j-easy/easy-flows.
 
 ## Comments On Easy Flow Usage
 
-Easy-Flows is under an MIT license, so we can use it in Parodos but its also in Read Only mode with no further development planned. As result, Parodos will use this for it's initial launch. Based on the feedback of this launch, a choice will need to be made for this project. Do we build upon what Easy-Flow started,create a new Workflow Management tool or integrate a different library? Care must be taken in this decision as such libraries are a slippery slope to implement and the requirements for Parodos are very simple.
+Easy-Flows is under an MIT license, so we can use it in Parodos but its also in Read Only mode with no further
+development planned. As result, Parodos will use this for it's initial launch. Based on the feedback of this launch, a
+choice will need to be made for this project. Do we build upon what Easy-Flow started,create a new Workflow Management
+tool or integrate a different library? Care must be taken in this decision as such libraries are a slippery slope to
+implement and the requirements for Parodos are very simple.
 
 In the meantime, we have only brought in the following concepts:
 
-- Work: An executable task. Used in Infrastructure Assessment, Events related to requesting infrastructure and the abstraction that sits above Pipelines
-- Workflow: A collection of Work that is executed in specific fashion. There are multiple implementations of Workflow included in the project
+- Work: An executable task. Used in Infrastructure Assessment, Events related to requesting infrastructure and the
+  abstraction that sits above Pipelines
+- Workflow: A collection of Work that is executed in specific fashion. There are multiple implementations of Workflow
+  included in the project
 - WorkContext: Resource passed into Work (can contain arguments for execution or the results of the work)
 - WorkReport: Returned from Work after its execution, useful in determining if the Work execution was successful
 

--- a/workflow-engine/README.md
+++ b/workflow-engine/README.md
@@ -1,16 +1,16 @@
 # Parodos Workflow Engine
 
-Parodos sits on top of existing tools and process in an enterprise environment. As a result, its assumed there will be
+Parodos sits on top of existing tools and process in an enterprise environment. As a result, it's assumed there will be
 existing workflow tool and business rules engine. However, within Parodos itself there is a need to execute tasks
 asynchronously while collecting their results.
 
-There are existing Workflow engines in Java, but many to be very complex (BPMN implementations), and as previously its
-assumed where Parodos is running there will will most likely be such engines/frameworks. As a result Parodos's current
+There are existing Workflow engines in Java but many are very complex (BPMN implementations), and as previously it's
+assumed where Parodos is running there will most likely be such engines/frameworks. As a result Parodos's current
 implementation for internally executing Workflows is https://github.com/j-easy/easy-flows.
 
 ## Comments On Easy Flow Usage
 
-Easy-Flows is under an MIT license, so we can use it in Parodos but its also in Read Only mode with no further
+Easy-Flows is under an MIT license, so we can use it in Parodos, but it's also in Read Only mode with no further
 development planned. As result, Parodos will use this for it's initial launch. Based on the feedback of this launch, a
 choice will need to be made for this project. Do we build upon what Easy-Flow started,create a new Workflow Management
 tool or integrate a different library? Care must be taken in this decision as such libraries are a slippery slope to
@@ -18,7 +18,7 @@ implement and the requirements for Parodos are very simple.
 
 In the meantime, we have only brought in the following concepts:
 
-- Work: An executable task. Used in Infrastructure Assessment, Events related to requesting infrastructure and the
+- Work: An executable task. Used in Infrastructure Assessment, events related to requesting infrastructure and the
   abstraction that sits above Pipelines
 - Workflow: A collection of Work that is executed in specific fashion. There are multiple implementations of Workflow
   included in the project

--- a/workflow-examples/README.md
+++ b/workflow-examples/README.md
@@ -16,7 +16,7 @@ The examples in this project can be found in two different packages.
 ### Simple
 
 This package shows different WorkflowTask(s) being created. The project shows how to create both Sequential and
-Parrellel workflows.
+Parallel workflows.
 
 ### Complex
 
@@ -34,10 +34,10 @@ mvn install
 
 ```
 
-### Adding The workflow-examples To The workflow-service
+### Adding The workflow-examples to the workflow-service
 
-Once the Jar has been compiled, ensure its added to the pom.xml of the workflow-service. This will allow the
-BeanWorkflowRegistryImpl to register the WorkflowTasks and Workflows.
+Once the Jar has been compiled, ensure it's added to the pom.xml of the workflow-service. This will allow the
+`BeanWorkflowRegistryImpl` to register the WorkflowTasks and Workflows.
 
 ```xml
 
@@ -51,9 +51,9 @@ BeanWorkflowRegistryImpl to register the WorkflowTasks and Workflows.
 ```
 
 Care must be taken when adding Workflow projects to the service to ensure that Workflows do not contradict other
-Workflows or dependencies in the Workflow do not override existing dependencies in the workflow-service.
+Workflows or dependencies in the Workflow and to not override existing dependencies in the workflow-service.
 
-Refer to the README of the workflow-service for how to build and start the application with this dependency in place.
+Refer to the README of the `workflow-service` for how to build and start the application with this dependency in place.
 
 ### Running to Examples
 
@@ -167,8 +167,8 @@ In this sample two such workflows can be seen:
 ```
 
 For the Workflow, the LogginWorkFlowTask argument is not defined in a @Bean method. This is because that WorkflowTask
-has the @Component annotation and can be created by Spring's bean factory using the default constructure. In contracts
-RestAPIWorkFlowTask needs a value supplied in the constructure to be created. As a result it is created in a method
+has the @Component annotation and can be created by Spring's bean factory using the default constructor. In contracts
+RestAPIWorkFlowTask needs a value supplied in the constructor to be created. As a result it is created in a method
 using the @Bean annotation. It's best practise to create a unique name for this Bean as there might be multiple version
 of Bean of this type created. In this example the default name is used (method name) to identify the Bean.
 
@@ -209,7 +209,7 @@ In this same configuration file, a simple Parallel Workflow can be defined.
 ```
 
 In this example 3 instances of the LoggingWorkFlowTask tasks are created and used in the Workflow. This is obviously
-just for example purposes as the instance of the Bean created by the Component could have been sufficied for refence in
+just for example purposes as the instance of the Bean created by the Component could have been sufficed for reference in
 the Workflow.
 
 In this example the usage of @Infrastructure can also be seen. By providing this annotation on the Workflow definition
@@ -223,8 +223,8 @@ To run these examples:
 
 ### Complex Workflow
 
-In this package the concept of a WorkflowChecker is demonstrated. This is a special WorkflowTask who's execute method
-calls a checkWorkFlowStatus method. It is intended to monitor if a manual process initated by another Workflow has
+In this package the concept of a WorkflowChecker is demonstrated. This is a special WorkflowTask who executes calls to a 
+checkWorkFlowStatus method. It is intended to monitor if a manual process initiated by another Workflow has
 completed.
 
 As can be seen in the MockApprovalWorkFlowCheckerTask when defining a WorkflowTask, after extending
@@ -236,11 +236,11 @@ and checking on their status before running other Workflows.
 
 Let's review the Workflows and their WorkflowCheckers.
 
-The concept of an Assessment Workflow is introduced in this configuration. This is specific WorkflowType that runs it's
+The concept of an Assessment Workflow is introduced in this configuration. This specific WorkflowType runs its
 execution logic and returns WorkflowOptions. A WorkflowOption provides a description of a Workflow and is useful when
 creating a UI that provides Users with a choice of which workflow to run.
 
-When defining a AssessmentTask, one or more WorkflowOption have to be supplied to the Task. In the execution logic it
+When defining an AssessmentTask, one or more WorkflowOption have to be supplied to the Task. In the execution logic it
 will determine which (if any) of these Options can be returned. The WorkflowOptions wrapper contains some groupings to
 place Workflow options that are IDP (internal developer platform) specific (ie: upgrading, migrating, onboarding
 workflows).
@@ -280,9 +280,9 @@ In this configuration section a Workflow is created that does an Assessment and 
 The WorkflowOption references a specific Workflow bean definition defined in the same file (onboardingWorkFlow" +
 WorkFlowConstants.INFRASTRUCTURE_WORKFLOW).
 
-This Workflow defintion can be found in the same configuration. For simplicity sake, the LoggingWorkFlowTask is used as
-the Task in this example by defining different instances of it, and refering to those instances by bean name when being
-referenced by a Workflow.
+This Workflow definition can be found in the same configuration. For simplicity’s sake, the LoggingWorkFlowTask is used
+as WorkflowTask in this example by defining different instances of it, and referring to those instances by bean name 
+when being referenced by a Workflow.
 
 ```java
 
@@ -347,28 +347,28 @@ The definition of that Workflow can be seen in the same configuration file.
 ```
 
 In the @Checker definition, the nextWorkFlowName can be specified. This is the Workflow that can run, provided the
-WorkflowChecker workflow successfully completes (meaning all WorkfTasks return COMPLETED). The ccronExpression of the
+WorkflowChecker workflow successfully completes (meaning all WorkflowTasks return COMPLETED). The cronExpression of the
 annotation will determine how often the Workflow will be executed. This is useful for manual processes that might take
 hours (or even days). As all state is persisted, when the workflow-service is restarted, execution will resume.
 
-WorkflowCheckers can be used to determine if required manual processes, outside of the scope of Parodos, have completed.
+WorkflowCheckers can be used to determine if required manual processes, outside the scope of Parodos, have completed.
 
 #### A Note On Defining WorkflowTasks for Usage In A Workflow
 
 ***Creating a Single Instance Of The Same Workflow Tasks***
 
-WorkflowTasks can be defined a Spring Components (@Component). In this case the workflow-service will detect the
-@Component tag and create a bean for this type. NOTE: When taking this option it key that all dependencies required to
+WorkflowTasks can be defined as Spring Components (@Component). In this case the workflow-service will detect the
+@Component tag and create a bean for this type. NOTE: When taking this option it keys that all dependencies required to
 create the WorkflowTasks are available as other Spring Components and/or configuration values. Any unspecified
 dependencies in a WorkflowTasks with @Component will result in the workflow-service being unable to start. By taking
-this approach the WorkflowTask can be used by multiple Workflows without any extra code outside of that used in the when
+this approach the WorkflowTask can be used by multiple Workflows without any extra code outside of that used in when
 defining the WorkflowTasks where @Component was declared.
 
 ***Defining a WorkflowTasks that can be change with Configuration***
 
 The values passed into a WorkflowTasks may vary depending on the Workflow using it. In this case the WorkflowTask can be
 defined as a regular Java class (do not use the @Component declaration). In a class with the declaration @Configuration,
-methods an be created returning an instance of the WorkflowTasks with different configurations applied to the reference.
+methods can be created returning an instance of the WorkflowTasks with different configurations applied to the reference.
 These methods should have the @Bean declaration. Also, multiple instances of the same type will be created (and Spring
 wires by type), the @Bean declaration should include a name (@Bean("myBean") or @Bean(name = "myBean")) . How this name
 is reference will be covered in the next section.
@@ -389,5 +389,4 @@ that the workflow-service has.
 
 If you find yourself creating over complex Tasks and WorkFlow, you are not using Parodos for its intended use case.
 Parodos is intended to tie together existing logic and tools. Tasks and WorkFlows should be posting messages on queues,
-calling APIs and other light weight integrations.
-
+calling APIs and other lightweight integrations.

--- a/workflow-examples/README.md
+++ b/workflow-examples/README.md
@@ -1,26 +1,32 @@
 # WorkFlow Examples
 
-This repository contains some examples of different WorkFlows that can be created with the Parodos infrastructure-service
+This repository contains some examples of different WorkFlows that can be created with the Parodos
+infrastructure-service
 
-Its recommended that you read the README for the 'parodos-model-api' prior to working with this sample. The README of the 'workflow-service' will explain how to execute the workflow. 
+Its recommended that you read the README for the 'parodos-model-api' prior to working with this sample. The README of
+the 'workflow-service' will explain how to execute the workflow.
 
 ## What Is In This Sample
 
-In this version of Parodos, Workflow projects are Java project. All configuration is done using the Spring Framework. These samples are built with Maven, however Gradle could also be used.
+In this version of Parodos, Workflow projects are Java project. All configuration is done using the Spring Framework.
+These samples are built with Maven, however Gradle could also be used.
 
 The examples in this project can be found in two different packages.
 
 ### Simple
 
-This package shows different WorkflowTask(s) being created. The project shows how to create both Sequential and Parrellel workflows.
+This package shows different WorkflowTask(s) being created. The project shows how to create both Sequential and
+Parrellel workflows.
 
 ### Complex
 
-This package shows how to work with WorkflowTasks that create a manual process that needs to be monitored before further WorkFlowTasks can be created. In this project WorkflowCheckers and other related concepts are created and configured.
+This package shows how to work with WorkflowTasks that create a manual process that needs to be monitored before further
+WorkFlowTasks can be created. In this project WorkflowCheckers and other related concepts are created and configured.
 
 ## Compiling The Code
 
-To get the Parodos dependencies you will need to run a maven install from the **root** of the project folder. This will build all the Java dependencies.
+To get the Parodos dependencies you will need to run a maven install from the **root** of the project folder. This will
+build all the Java dependencies.
 
 ```shell
 
@@ -30,8 +36,8 @@ mvn install
 
 ### Adding The workflow-examples To The workflow-service
 
-Once the Jar has been compiled, ensure its added to the pom.xml of the workflow-service. This will allow the BeanWorkflowRegistryImpl to register the WorkflowTasks and Workflows. 
-
+Once the Jar has been compiled, ensure its added to the pom.xml of the workflow-service. This will allow the
+BeanWorkflowRegistryImpl to register the WorkflowTasks and Workflows.
 
 ```xml
 
@@ -44,14 +50,15 @@ Once the Jar has been compiled, ensure its added to the pom.xml of the workflow-
 
 ```
 
-Care must be taken when adding Workflow projects to the service to ensure that Workflows do not contradict other Workflows or dependencies in the Workflow do not override existing dependencies in the workflow-service.
+Care must be taken when adding Workflow projects to the service to ensure that Workflows do not contradict other
+Workflows or dependencies in the Workflow do not override existing dependencies in the workflow-service.
 
 Refer to the README of the workflow-service for how to build and start the application with this dependency in place.
-
 
 ### Running to Examples
 
 To run these examples:
+
 - start the workflow-service in LOCAL mode for testing 'start_workflow_service.sh'
 - run the examples in this project 'run_examples.sh'
 
@@ -59,7 +66,9 @@ To run these examples:
 
 ### Defining Workflows and WorkflowTasks
 
-WorkflowTasks are the units that do the work in a Workflow. A Workflow executes Workflow tasks in an order specified when the Workflow object is created. For more details on these objects and their specific types, please review to the parodos-model-api for a detailed description of the object model.
+WorkflowTasks are the units that do the work in a Workflow. A Workflow executes Workflow tasks in an order specified
+when the Workflow object is created. For more details on these objects and their specific types, please review to the
+parodos-model-api for a detailed description of the object model.
 
 In this project how to configure these objects will be covered.
 
@@ -69,11 +78,14 @@ In this package the following WorkflowTasks are defined:
 
 - LoggingWorkFlowTask - write to the log of the 'workflow-service'
 - RestAPIWorkFlowTask - makes a REST call to a service and logs the response
-- SecureAPIGetTestTask - makes a secure call to a REST service and logs the response. Creates a base64 encoded header using values passed in as parameters
+- SecureAPIGetTestTask - makes a secure call to a REST service and logs the response. Creates a base64 encoded header
+  using values passed in as parameters
 
-The package contains the configuration file SimpleWorkFlowConfiguration where all the WorkflowTasks are configured and brought together in Workflows.
+The package contains the configuration file SimpleWorkFlowConfiguration where all the WorkflowTasks are configured and
+brought together in Workflows.
 
-The main logic of a WorkflowFlowTask is configured in the `execute` method. As can be seen the SecureAPIGetTestTask WorkflowTask.
+The main logic of a WorkflowFlowTask is configured in the `execute` method. As can be seen the SecureAPIGetTestTask
+WorkflowTask.
 
 ```java
 
@@ -101,7 +113,9 @@ public WorkReport execute(WorkContext workContext) {
 
 ```
 
-The execute section does the 'work' required by the task. It also needs to return a WorkReport indicating the WorkStatus (ie: COMPLETED, FAILED). In the case of a Sequential Workflow, the workflow will stop executing if the returned WorkReport has a WorkStatus of FAILED.
+The execute section does the 'work' required by the task. It also needs to return a WorkReport indicating the
+WorkStatus (ie: COMPLETED, FAILED). In the case of a Sequential Workflow, the workflow will stop executing if the
+returned WorkReport has a WorkStatus of FAILED.
 
 Parameters are obtained by overriding the following method defined in the WorkFlowTask interface.
 
@@ -124,7 +138,8 @@ For more information on the object model, please review the parodos-model-api RE
 
 ```
 
-Workflows are configured in a class with the @Configuration annotation. It is expected there will be at least one @Bean method returning a Workflow reference.
+Workflows are configured in a class with the @Configuration annotation. It is expected there will be at least one @Bean
+method returning a Workflow reference.
 
 In this sample two such workflows can be seen:
 
@@ -151,7 +166,11 @@ In this sample two such workflows can be seen:
 
 ```
 
-For the Workflow, the LogginWorkFlowTask argument is not defined in a @Bean method. This is because that WorkflowTask has the @Component annotation and can be created by Spring's bean factory using the default constructure. In contracts RestAPIWorkFlowTask needs a value supplied in the constructure to be created. As a result it is created in a method using the @Bean annotation. It's best practise to create a unique name for this Bean as there might be multiple version of Bean of this type created. In this example the default name is used (method name) to identify the Bean.
+For the Workflow, the LogginWorkFlowTask argument is not defined in a @Bean method. This is because that WorkflowTask
+has the @Component annotation and can be created by Spring's bean factory using the default constructure. In contracts
+RestAPIWorkFlowTask needs a value supplied in the constructure to be created. As a result it is created in a method
+using the @Bean annotation. It's best practise to create a unique name for this Bean as there might be multiple version
+of Bean of this type created. In this example the default name is used (method name) to identify the Bean.
 
 In this same configuration file, a simple Parallel Workflow can be defined.
 
@@ -189,27 +208,42 @@ In this same configuration file, a simple Parallel Workflow can be defined.
 
 ```
 
-In this example 3 instances of the LoggingWorkFlowTask tasks are created and used in the Workflow. This is obviously just for example purposes as the instance of the Bean created by the Component could have been sufficied for refence in the Workflow.
+In this example 3 instances of the LoggingWorkFlowTask tasks are created and used in the Workflow. This is obviously
+just for example purposes as the instance of the Bean created by the Component could have been sufficied for refence in
+the Workflow.
 
-In this example the usage of @Infrastructure can also be seen. By providing this annotation on the Workflow definition it allows the workflow-service to perform underlying tasks specific to that Workflow type. Refer to the parodos-model-api README for more information on these annotations.
+In this example the usage of @Infrastructure can also be seen. By providing this annotation on the Workflow definition
+it allows the workflow-service to perform underlying tasks specific to that Workflow type. Refer to the
+parodos-model-api README for more information on these annotations.
 
 To run these examples:
+
 - start the workflow-service in LOCAL mode for testing 'start_workflow_service.sh'
 - run the examples in this project 'run_examples.sh'
 
 ### Complex Workflow
 
-In this package the concept of a WorkflowChecker is demonstrated. This is a special WorkflowTask who's execute method calls a checkWorkFlowStatus method. It is intended to monitor if a manual process initated by another Workflow has completed.
+In this package the concept of a WorkflowChecker is demonstrated. This is a special WorkflowTask who's execute method
+calls a checkWorkFlowStatus method. It is intended to monitor if a manual process initated by another Workflow has
+completed.
 
-As can be seen in the MockApprovalWorkFlowCheckerTask when defining a WorkflowTask, after extending BaseWorkFlowCheckerTask, only the checkWorkFlowStatus method needs to be defined. In this example is returns a COMPLETED workflow status on the first call. In practise, this method might be called many times before such a state is obtained.
+As can be seen in the MockApprovalWorkFlowCheckerTask when defining a WorkflowTask, after extending
+BaseWorkFlowCheckerTask, only the checkWorkFlowStatus method needs to be defined. In this example is returns a COMPLETED
+workflow status on the first call. In practise, this method might be called many times before such a state is obtained.
 
-The ComplexWorkFlowConfiguration is where things get interesting. This file demonstrates running different WorkflowTasks and checking on their status before running other Workflows.
+The ComplexWorkFlowConfiguration is where things get interesting. This file demonstrates running different WorkflowTasks
+and checking on their status before running other Workflows.
 
 Let's review the Workflows and their WorkflowCheckers.
 
-The concept of an Assessment Workflow is introduced in this configuration. This is specific WorkflowType that runs it's execution logic and returns WorkflowOptions. A WorkflowOption provides a description of a Workflow and is useful when creating a UI that provides Users with a choice of which workflow to run.
+The concept of an Assessment Workflow is introduced in this configuration. This is specific WorkflowType that runs it's
+execution logic and returns WorkflowOptions. A WorkflowOption provides a description of a Workflow and is useful when
+creating a UI that provides Users with a choice of which workflow to run.
 
-When defining a AssessmentTask, one or more WorkflowOption have to be supplied to the Task. In the execution logic it will determine which (if any) of these Options can be returned. The WorkflowOptions wrapper contains some groupings to place Workflow options that are IDP (internal developer platform) specific (ie: upgrading, migrating, onboarding workflows).
+When defining a AssessmentTask, one or more WorkflowOption have to be supplied to the Task. In the execution logic it
+will determine which (if any) of these Options can be returned. The WorkflowOptions wrapper contains some groupings to
+place Workflow options that are IDP (internal developer platform) specific (ie: upgrading, migrating, onboarding
+workflows).
 
 In this configuration section a Workflow is created that does an Assessment and returns a WorkflowOption.
 
@@ -243,9 +277,12 @@ In this configuration section a Workflow is created that does an Assessment and 
 
 ```
 
-The WorkflowOption references a specific Workflow bean definition defined in the same file (onboardingWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW).
+The WorkflowOption references a specific Workflow bean definition defined in the same file (onboardingWorkFlow" +
+WorkFlowConstants.INFRASTRUCTURE_WORKFLOW).
 
-This Workflow defintion can be found in the same configuration. For simplicity sake, the LoggingWorkFlowTask is used as the Task in this example by defining different instances of it, and refering to those instances by bean name when being referenced by a Workflow.
+This Workflow defintion can be found in the same configuration. For simplicity sake, the LoggingWorkFlowTask is used as
+the Task in this example by defining different instances of it, and refering to those instances by bean name when being
+referenced by a Workflow.
 
 ```java
 
@@ -292,7 +329,8 @@ This Workflow defintion can be found in the same configuration. For simplicity s
 
 ```
 
-Here the concept of WorkflowChecker can be seen in the WorkflowTask configurations. For example certWorkFlowTask references the WorkflowChecker namespaceWorkFlowCheckerWorkFlow.
+Here the concept of WorkflowChecker can be seen in the WorkflowTask configurations. For example certWorkFlowTask
+references the WorkflowChecker namespaceWorkFlowCheckerWorkFlow.
 
 The definition of that Workflow can be seen in the same configuration file.
 
@@ -308,7 +346,10 @@ The definition of that Workflow can be seen in the same configuration file.
 
 ```
 
-In the @Checker definition, the nextWorkFlowName can be specified. This is the Workflow that can run, provided the WorkflowChecker workflow successfully completes (meaning all WorkfTasks return COMPLETED). The ccronExpression of the annotation will determine how often the Workflow will be executed. This is useful for manual processes that might take hours (or even days). As all state is persisted, when the workflow-service is restarted, execution will resume.
+In the @Checker definition, the nextWorkFlowName can be specified. This is the Workflow that can run, provided the
+WorkflowChecker workflow successfully completes (meaning all WorkfTasks return COMPLETED). The ccronExpression of the
+annotation will determine how often the Workflow will be executed. This is useful for manual processes that might take
+hours (or even days). As all state is persisted, when the workflow-service is restarted, execution will resume.
 
 WorkflowCheckers can be used to determine if required manual processes, outside of the scope of Parodos, have completed.
 
@@ -316,21 +357,37 @@ WorkflowCheckers can be used to determine if required manual processes, outside 
 
 ***Creating a Single Instance Of The Same Workflow Tasks***
 
-WorkflowTasks can be defined a Spring Components (@Component). In this case the workflow-service will detect the @Component tag and create a bean for this type. NOTE: When taking this option it key that all dependencies required to create the WorkflowTasks are available as other Spring Components and/or configuration values. Any unspecified dependencies in a WorkflowTasks with @Component will result in the workflow-service being unable to start. By taking this approach the WorkflowTask can be used by multiple Workflows without any extra code outside of that used in the when defining the WorkflowTasks where @Component was declared.
+WorkflowTasks can be defined a Spring Components (@Component). In this case the workflow-service will detect the
+@Component tag and create a bean for this type. NOTE: When taking this option it key that all dependencies required to
+create the WorkflowTasks are available as other Spring Components and/or configuration values. Any unspecified
+dependencies in a WorkflowTasks with @Component will result in the workflow-service being unable to start. By taking
+this approach the WorkflowTask can be used by multiple Workflows without any extra code outside of that used in the when
+defining the WorkflowTasks where @Component was declared.
 
 ***Defining a WorkflowTasks that can be change with Configuration***
 
-The values passed into a WorkflowTasks may vary depending on the Workflow using it. In this case the WorkflowTask can be defined as a regular Java class (do not use the @Component declaration). In a class with the declaration @Configuration, methods an be created returning an instance of the WorkflowTasks with different configurations applied to the reference. These methods should have the @Bean declaration. Also, multiple instances of the same type will be created (and Spring wires by type), the @Bean declaration should include a name (@Bean("myBean") or @Bean(name = "myBean")) . How this name is reference will be covered in the next section.
+The values passed into a WorkflowTasks may vary depending on the Workflow using it. In this case the WorkflowTask can be
+defined as a regular Java class (do not use the @Component declaration). In a class with the declaration @Configuration,
+methods an be created returning an instance of the WorkflowTasks with different configurations applied to the reference.
+These methods should have the @Bean declaration. Also, multiple instances of the same type will be created (and Spring
+wires by type), the @Bean declaration should include a name (@Bean("myBean") or @Bean(name = "myBean")) . How this name
+is reference will be covered in the next section.
 
 ***Package Structures and Workflow-Service's BeanWorkFlowRegistryImpl***
 
-Ensure your packages have the base of 'com.redhat.parodos'. If a different structure is used, 'com.mycompany.parodos' for example, any WorkFlows and Tasks defined will not be detected by the BeanWorkFlowRegistryImpl of the workflow-service.
+Ensure your packages have the base of 'com.redhat.parodos'. If a different structure is used, 'com.mycompany.parodos'
+for example, any WorkFlows and Tasks defined will not be detected by the BeanWorkFlowRegistryImpl of the
+workflow-service.
 
 ***A Word On Dependencies***
 
-Please review the dependencies included in the workflow-service and ensure when creating Tasks and WorkFlows in an external Jar (such as outlined in this project) that dependencies are not included that override existing dependencies that the workflow-service has.
+Please review the dependencies included in the workflow-service and ensure when creating Tasks and WorkFlows in an
+external Jar (such as outlined in this project) that dependencies are not included that override existing dependencies
+that the workflow-service has.
 
 ***Tips On Task and WorkFlow Complexity***
 
-If you find yourself creating over complex Tasks and WorkFlow, you are not using Parodos for its intended use case. Parodos is intended to tie together existing logic and tools. Tasks and WorkFlows should be posting messages on queues, calling APIs and other light weight integrations.
+If you find yourself creating over complex Tasks and WorkFlow, you are not using Parodos for its intended use case.
+Parodos is intended to tie together existing logic and tools. Tasks and WorkFlows should be posting messages on queues,
+calling APIs and other light weight integrations.
 

--- a/workflow-service/README.md
+++ b/workflow-service/README.md
@@ -4,7 +4,8 @@ This service is designed run Parodos Workflows (composed of Parodos WorkflowTask
 
 ## Starting The Service Locally
 
-To compile all the components required for this project to work run the maven parent pom in the root directory of the service folder.
+To compile all the components required for this project to work run the maven parent pom in the root directory of the
+service folder.
 
 ```shell
 
@@ -12,9 +13,11 @@ mvn clean package
 
 ```
 
-Note: It is assumed 'mvn install' has already been executed at the root level of the project to generate the WorkEngine dependencies into your local maven repository. If this has not been completed the workflow-service will not compile.
+Note: It is assumed 'mvn install' has already been executed at the root level of the project to generate the WorkEngine
+dependencies into your local maven repository. If this has not been completed the workflow-service will not compile.
 
-The 'workflow-examples' dependency can be found in the pom.xml of the workflow-service. This is a demo configuration to test the service. It should be removed once actual Tasks and WorkFlows start getting created.
+The 'workflow-examples' dependency can be found in the pom.xml of the workflow-service. This is a demo configuration to
+test the service. It should be removed once actual Tasks and WorkFlows start getting created.
 
 To start the application run the following from the root folder of 'workflow-service'.
 
@@ -24,21 +27,29 @@ java -Dspring.profiles.active=local -jar target/workflow-service-0.0.1-SNAPSHOT.
 
 ```
 
-For convience there is a shell script at the root of the folder that will run this command as well (start_workflow_service.sh).
+For convience there is a shell script at the root of the folder that will run this command as well (
+start_workflow_service.sh).
 
-The 'local' is intended for local testing and runs the application without security (Keycloak managed Oauth2 flow is the default). Documentation is currently being produced for production grade security configurations.
+The 'local' is intended for local testing and runs the application without security (Keycloak managed Oauth2 flow is the
+default). Documentation is currently being produced for production grade security configurations.
 
 ## Defining Workflows And WorkFlowTasks
 
-More detail on this subject will be covered in the 'parodos-model-api' folder of this project. For a complete example please review 'workflow-example'.
+More detail on this subject will be covered in the 'parodos-model-api' folder of this project. For a complete example
+please review 'workflow-example'.
 
-In this present release teams are encouraged to think of Workflows and WorkflowTasks as stand alone Java projects. As such they should have test coverage, undergo a full software release cycle and should not be updated in production trivally. Due to the persistance of both workflow definitions and WorkflowTask executions, the workflow-service can be restarted to update the definition of Workflows and WorkflowTasks.
+In this present release teams are encouraged to think of Workflows and WorkflowTasks as stand alone Java projects. As
+such they should have test coverage, undergo a full software release cycle and should not be updated in production
+trivally. Due to the persistance of both workflow definitions and WorkflowTask executions, the workflow-service can be
+restarted to update the definition of Workflows and WorkflowTasks.
 
-**Note:** Future release of this service will include WorkFlowTask/WorkFlow creation/configuration options that do not require having to write Java code.
+**Note:** Future release of this service will include WorkFlowTask/WorkFlow creation/configuration options that do not
+require having to write Java code.
 
 ## Loading WorkFlows into the Application
 
-The Workflow Service is designed out-of-the-box to detect and load the WorkFlows using an implementation of WorkFlowRegistry.
+The Workflow Service is designed out-of-the-box to detect and load the WorkFlows using an implementation of
+WorkFlowRegistry.
 
 ```java
 
@@ -55,15 +66,20 @@ public interface WorkFlowRegistry<T> {
 
 ```
 
-The BeanWorkflowRegistryImpl will load all Spring Beans of type: com.redhat.parodos.workflows.workflow.WorkFlow into the registry which will in turn make them available for their respective Services (they must be in the package 'com.redhat.parodos' to be detected). WorkflowTasks and Workflows can be created using @Bean and @Configuration annotations of the Spring Framework. 
+The BeanWorkflowRegistryImpl will load all Spring Beans of type: com.redhat.parodos.workflows.workflow.WorkFlow into the
+registry which will in turn make them available for their respective Services (they must be in the package '
+com.redhat.parodos' to be detected). WorkflowTasks and Workflows can be created using @Bean and @Configuration
+annotations of the Spring Framework.
 
-This can be done as part of the workflow-service's code base, or in a separate Jar that can add to the class path of the workflow-service. 
+This can be done as part of the workflow-service's code base, or in a separate Jar that can add to the class path of the
+workflow-service.
 
 Please review the Parodos project 'workflow-examples' for more details.
 
 ## Service Endpoint Overview
 
-Swagger can be accessed when running locally with http://localhost:8080. The username/password of test/test will grant access locally.
+Swagger can be accessed when running locally with http://localhost:8080. The username/password of test/test will grant
+access locally.
 
 ![Workflow-Service](readme-images/swagger.png)
 
@@ -73,31 +89,44 @@ The workflow-service provides the following endpoints:
 
 ***Projects***
 
-- GET  http://localhost:8080/api/v1/projects - Gets all the projects being managed with the workflow-service. Workflows act upon Projects
+- GET  http://localhost:8080/api/v1/projects - Gets all the projects being managed with the workflow-service. Workflows
+  act upon Projects
 - POST  http://localhost:8080/api/v1/projects - Create a new Project
 - GET http://localhost:8080/api/v1/projects/{projectId} - Gets a specific Project reference
 
 ***Workflow***
+
 - POST http://localhost:8080/api/v1/workflows - Used to execute a Workflow
 
 ***Workflow Definition***
-- GET http://localhost:8080/api/v1/workflowdefinitions - Gets all the workflow definitions (this is the meta data of a Workflow and includes associated WorkflowTasks and WorkflowParameters)
-- GET http://localhost:8080/api/v1/workflowdefinitions/{workflowId} - Gets a specific workflow definition (this is the meta data of a Workflow and includes associated WorkflowTasks and WorkflowParameters)
 
+- GET http://localhost:8080/api/v1/workflowdefinitions - Gets all the workflow definitions (this is the meta data of a
+  Workflow and includes associated WorkflowTasks and WorkflowParameters)
+- GET http://localhost:8080/api/v1/workflowdefinitions/{workflowId} - Gets a specific workflow definition (this is the
+  meta data of a Workflow and includes associated WorkflowTasks and WorkflowParameters)
 
 ## FAQ
 
 ### Why doesn't the service use a more mature/feature rich Business Rules engine?
 
-It is assumed that Parodos will be running in enterprise environments where there will be many tools and platforms available. As a result Parodos has not interest in trying to compete with such tools. The approach is to send the appropriate data to these existing tools, and the most appropriate time to allow for them to be more effectively used and integrated with other tools.
+It is assumed that Parodos will be running in enterprise environments where there will be many tools and platforms
+available. As a result Parodos has not interest in trying to compete with such tools. The approach is to send the
+appropriate data to these existing tools, and the most appropriate time to allow for them to be more effectively used
+and integrated with other tools.
 
 ### These workflows are not advanced enough for me to perform the automation tasks I need. Will more automation features be added to Parodos?
 
-If you are finding Parodos's simple workflows not advanced enough to manage the creation and configuration of your tools you are not using Parodos in its intended purpose. Automation tools such as Ansible or Terraform should be used to manage the creation and update of infrastructure. Tools such as Jira Service desk and should manage permission workflows. Think of Parodos as a way to tie these disparate systems together for a more comprehensive experience for consumers of the tools. If you are lacking such automation and tools, it might not be the right time for you to use Parodos
+If you are finding Parodos's simple workflows not advanced enough to manage the creation and configuration of your tools
+you are not using Parodos in its intended purpose. Automation tools such as Ansible or Terraform should be used to
+manage the creation and update of infrastructure. Tools such as Jira Service desk and should manage permission
+workflows. Think of Parodos as a way to tie these disparate systems together for a more comprehensive experience for
+consumers of the tools. If you are lacking such automation and tools, it might not be the right time for you to use
+Parodos
 
 ### Will there be support to configure rules beyond Spring Beans?
 
-Yes. In this first release a configuration pattern widely used across many enterprise environments was chosen. However future release will include a DSL (domain specific language) for configuring Workflows without have to write Java code.
+Yes. In this first release a configuration pattern widely used across many enterprise environments was chosen. However
+future release will include a DSL (domain specific language) for configuring Workflows without have to write Java code.
 
 
 

--- a/workflow-service/README.md
+++ b/workflow-service/README.md
@@ -27,8 +27,8 @@ java -Dspring.profiles.active=local -jar target/workflow-service-0.0.1-SNAPSHOT.
 
 ```
 
-For convience there is a shell script at the root of the folder that will run this command as well (
-start_workflow_service.sh).
+For convenience there is a shell script at the root of the folder that will run this command as well 
+(`start_workflow_service.sh`).
 
 The 'local' is intended for local testing and runs the application without security (Keycloak managed Oauth2 flow is the
 default). Documentation is currently being produced for production grade security configurations.
@@ -40,7 +40,7 @@ please review 'workflow-example'.
 
 In this present release teams are encouraged to think of Workflows and WorkflowTasks as stand alone Java projects. As
 such they should have test coverage, undergo a full software release cycle and should not be updated in production
-trivally. Due to the persistance of both workflow definitions and WorkflowTask executions, the workflow-service can be
+trivially. Due to the persistence of both workflow definitions and WorkflowTask executions, the workflow-service can be
 restarted to update the definition of Workflows and WorkflowTasks.
 
 **Note:** Future release of this service will include WorkFlowTask/WorkFlow creation/configuration options that do not
@@ -54,13 +54,13 @@ WorkFlowRegistry.
 ```java
 
 public interface WorkFlowRegistry<T> {
-	
+
     Set<T> getRegisteredWorkFlowNames();
-    
-    Map<T,WorkFlow> getAllRegisteredWorkFlows();
-    
+
+    Map<T, WorkFlow> getAllRegisteredWorkFlows();
+
     WorkFlow getWorkFlowById(T id);
-    
+
     Collection<T> getRegisteredWorkFlowNamesByWorkType(String typeName);
 }
 
@@ -100,17 +100,17 @@ The workflow-service provides the following endpoints:
 
 ***Workflow Definition***
 
-- GET http://localhost:8080/api/v1/workflowdefinitions - Gets all the workflow definitions (this is the meta data of a
+- GET http://localhost:8080/api/v1/workflowdefinitions - Gets all the workflow definitions (this is the metadata of a
   Workflow and includes associated WorkflowTasks and WorkflowParameters)
 - GET http://localhost:8080/api/v1/workflowdefinitions/{workflowId} - Gets a specific workflow definition (this is the
-  meta data of a Workflow and includes associated WorkflowTasks and WorkflowParameters)
+  metadata of a Workflow and includes associated WorkflowTasks and WorkflowParameters)
 
 ## FAQ
 
 ### Why doesn't the service use a more mature/feature rich Business Rules engine?
 
 It is assumed that Parodos will be running in enterprise environments where there will be many tools and platforms
-available. As a result Parodos has not interest in trying to compete with such tools. The approach is to send the
+available. As a result Parodos has not interested in trying to compete with such tools. The approach is to send the
 appropriate data to these existing tools, and the most appropriate time to allow for them to be more effectively used
 and integrated with other tools.
 
@@ -118,16 +118,12 @@ and integrated with other tools.
 
 If you are finding Parodos's simple workflows not advanced enough to manage the creation and configuration of your tools
 you are not using Parodos in its intended purpose. Automation tools such as Ansible or Terraform should be used to
-manage the creation and update of infrastructure. Tools such as Jira Service desk and should manage permission
+manage the creation and update of infrastructure. Tools such as Jira Service desk should manage permission
 workflows. Think of Parodos as a way to tie these disparate systems together for a more comprehensive experience for
 consumers of the tools. If you are lacking such automation and tools, it might not be the right time for you to use
 Parodos
 
 ### Will there be support to configure rules beyond Spring Beans?
 
-Yes. In this first release a configuration pattern widely used across many enterprise environments was chosen. However
+Yes. In this first release a configuration pattern widely used across many enterprise environments was chosen. However,
 future release will include a DSL (domain specific language) for configuring Workflows without have to write Java code.
-
-
-
-


### PR DESCRIPTION
This PR fixed some typos present in README files.
In addition, It reformats README files using line length equals to 120 chars. This is necessary to ease the read of the raw file and to ease the edits on the text.