### PR TITLE
FLPATH-43: Create and use custom Exception classes for throwables

### DIFF
--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/NotificationRecordNotFoundException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/NotificationRecordNotFoundException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Red Hat Developer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.parodos.notification.exceptions;
+
+/**
+ * The NotificationRecordNotFoundException wraps unchecked standard Java exception and
+ * enriches them with a custom error code. You can use this execution when there is a miss
+ * in NotificationRecordRepository.
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+
+public class NotificationRecordNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public NotificationRecordNotFoundException() {
+	}
+
+	public NotificationRecordNotFoundException(String message) {
+		super(message);
+	}
+
+	public NotificationRecordNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public NotificationRecordNotFoundException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/NotificationRecordNotFoundException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/NotificationRecordNotFoundException.java
@@ -27,19 +27,8 @@ public class NotificationRecordNotFoundException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public NotificationRecordNotFoundException() {
-	}
-
 	public NotificationRecordNotFoundException(String message) {
 		super(message);
-	}
-
-	public NotificationRecordNotFoundException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
-	public NotificationRecordNotFoundException(Throwable cause) {
-		super(cause);
 	}
 
 }

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/SearchByStateAndTermNotSupportedException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/SearchByStateAndTermNotSupportedException.java
@@ -26,19 +26,8 @@ public class SearchByStateAndTermNotSupportedException extends RuntimeException 
 
 	private static final long serialVersionUID = 1L;
 
-	public SearchByStateAndTermNotSupportedException() {
-	}
-
 	public SearchByStateAndTermNotSupportedException(String message) {
 		super(message);
-	}
-
-	public SearchByStateAndTermNotSupportedException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
-	public SearchByStateAndTermNotSupportedException(Throwable cause) {
-		super(cause);
 	}
 
 }

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/SearchByStateAndTermNotSupportedException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/SearchByStateAndTermNotSupportedException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Red Hat Developer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.parodos.notification.exceptions;
+
+/**
+ * The SearchByStateAndTermNotSupportedException wraps unchecked standard Java exception
+ * and enriches them with a custom error code. You can use this execution when both Search
+ * By State and Search by Term are set.
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public class SearchByStateAndTermNotSupportedException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public SearchByStateAndTermNotSupportedException() {
+	}
+
+	public SearchByStateAndTermNotSupportedException(String message) {
+		super(message);
+	}
+
+	public SearchByStateAndTermNotSupportedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public SearchByStateAndTermNotSupportedException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/StateNotFoundOrUnsupportedException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/StateNotFoundOrUnsupportedException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Red Hat Developer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.parodos.notification.exceptions;
+
+/**
+ * The StateNotFoundOrUnsupportedException wraps unchecked standard Java exception and
+ * enriches them with a custom error code. You can use this execution when a Notification
+ * State is not found or is unsupported.
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public class StateNotFoundOrUnsupportedException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public StateNotFoundOrUnsupportedException() {
+	}
+
+	public StateNotFoundOrUnsupportedException(String message) {
+		super(message);
+	}
+
+	public StateNotFoundOrUnsupportedException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public StateNotFoundOrUnsupportedException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UsernameNotFoundException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UsernameNotFoundException.java
@@ -26,19 +26,8 @@ public class UsernameNotFoundException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public UsernameNotFoundException() {
-	}
-
 	public UsernameNotFoundException(String message) {
 		super(message);
-	}
-
-	public UsernameNotFoundException(String message, Throwable cause) {
-		super(message, cause);
-	}
-
-	public UsernameNotFoundException(Throwable cause) {
-		super(cause);
 	}
 
 }

--- a/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UsernameNotFoundException.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/exceptions/UsernameNotFoundException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Red Hat Developer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.parodos.notification.exceptions;
+
+/**
+ * The UsernameNotFoundException wraps unchecked standard Java exception and enriches them
+ * with a custom error code. You can use this execution when there is a miss in
+ * NotificationUserRepository.
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public class UsernameNotFoundException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public UsernameNotFoundException() {
+	}
+
+	public UsernameNotFoundException(String message) {
+		super(message);
+	}
+
+	public UsernameNotFoundException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public UsernameNotFoundException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationRecordServiceImpl.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/service/impl/NotificationRecordServiceImpl.java
@@ -15,9 +15,12 @@
  */
 package com.redhat.parodos.notification.service.impl;
 
+import com.redhat.parodos.notification.enums.Operation;
 import com.redhat.parodos.notification.enums.SearchCriteria;
 import com.redhat.parodos.notification.enums.State;
-import com.redhat.parodos.notification.enums.Operation;
+import com.redhat.parodos.notification.exceptions.NotificationRecordNotFoundException;
+import com.redhat.parodos.notification.exceptions.StateNotFoundOrUnsupportedException;
+import com.redhat.parodos.notification.exceptions.UsernameNotFoundException;
 import com.redhat.parodos.notification.jpa.entity.NotificationMessage;
 import com.redhat.parodos.notification.jpa.entity.NotificationRecord;
 import com.redhat.parodos.notification.jpa.entity.NotificationUser;
@@ -25,14 +28,15 @@ import com.redhat.parodos.notification.jpa.repository.NotificationRecordReposito
 import com.redhat.parodos.notification.jpa.repository.NotificationUserRepository;
 import com.redhat.parodos.notification.service.NotificationRecordService;
 import com.redhat.parodos.notification.util.SearchUtil;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * @author Richard Wang (Github: RichardW98)
@@ -101,9 +105,8 @@ public class NotificationRecordServiceImpl implements NotificationRecordService 
 						.map(notificationRecordRepository::countDistinctByReadFalseAndNotificationUserListContaining)
 						.orElse(0);
 			default:
-				throw new RuntimeException(String.format("State %s is not supported", state));
+				throw new StateNotFoundOrUnsupportedException(String.format("State %s is not supported", state));
 		}
-
 	}
 
 	@Override
@@ -114,7 +117,7 @@ public class NotificationRecordServiceImpl implements NotificationRecordService 
 			case ARCHIVE:
 				return updateArchiveFolder(id);
 			default:
-				throw new RuntimeException(String.format("Operation %s is not supported", operation));
+				throw new UnsupportedOperationException(String.format("Operation %s is not supported", operation));
 		}
 	}
 
@@ -131,7 +134,7 @@ public class NotificationRecordServiceImpl implements NotificationRecordService 
 	private NotificationUser getNotificationUser(String username) {
 		Optional<NotificationUser> notificationsUser = this.notificationUserRepository.findByUsername(username);
 		if (notificationsUser.isEmpty()) {
-			throw new RuntimeException(String.format("Username %s not found", username));
+			throw new UsernameNotFoundException(String.format("Username %s not found", username));
 		}
 		return notificationsUser.get();
 	}
@@ -151,7 +154,8 @@ public class NotificationRecordServiceImpl implements NotificationRecordService 
 	private Optional<NotificationRecord> findRecordById(UUID id) {
 		Optional<NotificationRecord> notificationsRecordOptional = this.notificationRecordRepository.findById(id);
 		if (notificationsRecordOptional.isEmpty()) {
-			throw new RuntimeException(String.format("Could not find NotificationRecord for id = %s", id));
+			throw new NotificationRecordNotFoundException(
+					String.format("Could not find NotificationRecord for id = %s", id));
 		}
 		return notificationsRecordOptional;
 	}

--- a/notification-service/src/main/java/com/redhat/parodos/notification/util/SearchUtil.java
+++ b/notification-service/src/main/java/com/redhat/parodos/notification/util/SearchUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.isNull;
 
 import com.redhat.parodos.notification.enums.SearchCriteria;
 import com.redhat.parodos.notification.enums.State;
+import com.redhat.parodos.notification.exceptions.SearchByStateAndTermNotSupportedException;
 
 /**
  * Notification records search util
@@ -30,7 +31,7 @@ public class SearchUtil {
 		else if (isStateUnset) {
 			return SearchCriteria.BY_USERNAME_AND_SEARCH_TERM;
 		}
-		throw new RuntimeException("Search by state and search term combined not supported");
+		throw new SearchByStateAndTermNotSupportedException("Search by state and search term combined not supported");
 	}
 
 }

--- a/workflow-engine/src/main/java/com/redhat/parodos/workflows/exceptions/ParallelFlowInterruptedException.java
+++ b/workflow-engine/src/main/java/com/redhat/parodos/workflows/exceptions/ParallelFlowInterruptedException.java
@@ -13,21 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.redhat.parodos.notification.exceptions;
+package com.redhat.parodos.workflows.exceptions;
 
 /**
- * The StateNotFoundOrUnsupportedException wraps unchecked standard Java exception and
- * enriches them with a custom error code. You can use this execution when a Notification
- * State is not found or is unsupported.
+ * The ParallelFlowInterruptedException wraps unchecked standard Java exception and
+ * enriches them with a custom error code. You can use this execution when a flow is
+ * interrupted during a parallel execution.
  *
  * @author Gloria Ciavarrini (Github: gciavarrini)
  */
-public class StateNotFoundOrUnsupportedException extends RuntimeException {
+
+public class ParallelFlowInterruptedException extends Exception {
 
 	private static final long serialVersionUID = 1L;
 
-	public StateNotFoundOrUnsupportedException(String message) {
-		super(message);
+	public ParallelFlowInterruptedException(String message, Throwable cause) {
+		super(message, cause);
 	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
@@ -23,6 +23,8 @@ import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import com.redhat.parodos.workflow.exceptions.WorkflowDefinitionException;
 import org.modelmapper.Converter;
 import org.modelmapper.spi.MappingContext;
 
@@ -56,7 +58,7 @@ public class WorkFlowTaskDefinitionDTOConverter
 						.build();
 			}
 			catch (JsonProcessingException e) {
-				throw new RuntimeException(e);
+				throw new WorkflowDefinitionException(e);
 			}
 		}).collect(Collectors.toList());
 	}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/exceptions/WorkflowDefinitionException.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/exceptions/WorkflowDefinitionException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022 Red Hat Developer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.parodos.workflow.exceptions;
+
+/**
+ * The WorkflowDefinitionException wraps unchecked standard Java exception and enriches
+ * them with a custom error code. You can use this execution when a Workflow has not been
+ * properly defined.
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+
+public class WorkflowDefinitionException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	public WorkflowDefinitionException() {
+	}
+
+	public WorkflowDefinitionException(String message) {
+		super(message);
+	}
+
+	public WorkflowDefinitionException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public WorkflowDefinitionException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/exceptions/WorkflowDefinitionException.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/exceptions/WorkflowDefinitionException.java
@@ -27,15 +27,8 @@ public class WorkflowDefinitionException extends RuntimeException {
 
 	private static final long serialVersionUID = 1L;
 
-	public WorkflowDefinitionException() {
-	}
-
 	public WorkflowDefinitionException(String message) {
 		super(message);
-	}
-
-	public WorkflowDefinitionException(String message, Throwable cause) {
-		super(message, cause);
 	}
 
 	public WorkflowDefinitionException(Throwable cause) {

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/execution/continuation/WorkFlowContinuationService.java
@@ -22,6 +22,7 @@ import com.redhat.parodos.workflow.WorkFlowStatus;
 import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
 import com.redhat.parodos.workflow.definition.repository.WorkFlowTaskDefinitionRepository;
+import com.redhat.parodos.workflow.exceptions.WorkflowDefinitionException;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowExecution;
 import com.redhat.parodos.workflow.execution.entity.WorkFlowTaskExecution;
 import com.redhat.parodos.workflow.execution.repository.WorkFlowRepository;
@@ -96,7 +97,7 @@ public class WorkFlowContinuationService {
 									}));
 						}
 						catch (JsonProcessingException e) {
-							throw new RuntimeException(e);
+							throw new WorkflowDefinitionException(e);
 						}
 					});
 					workFlowService.execute(workFlowExecution.getProjectId().toString(), workFlowDefinition.getName(),

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
@@ -22,6 +22,7 @@ import com.redhat.parodos.workflow.annotation.Checker;
 import com.redhat.parodos.workflow.annotation.Infrastructure;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowCheckerDTO;
 import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
+import com.redhat.parodos.workflow.exceptions.WorkflowDefinitionException;
 import com.redhat.parodos.workflow.task.WorkFlowTask;
 import com.redhat.parodos.workflows.workflow.WorkFlow;
 import javax.annotation.PostConstruct;
@@ -135,7 +136,7 @@ public class BeanWorkFlowRegistryImpl implements WorkFlowRegistry<String> {
 							metadata.getAnnotationAttributes(clazz.getName())))
 					.orElseThrow(() -> new RuntimeException("workflow missing type!"));
 		}
-		throw new RuntimeException("workflow with no annotated type metadata!");
+		throw new WorkflowDefinitionException("workflow with no annotated type metadata!");
 	}
 
 	@Override


### PR DESCRIPTION
This PR introduces custom exceptions that wrap uncheck Java exceptions.
Affected modules are: `workflow-service`, `workflow-engine`, and `notification-service`.