### PR TITLE
FLPATH-9: Add unit tests for `workflow-examples` package

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -49,6 +49,11 @@
       <version>${project.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>workflow-examples</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -57,6 +57,11 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.8</version>
+        <configuration>
+          <excludes>
+            <exclude>**/*Configuration.*</exclude>
+          </excludes>
+        </configuration>
         <executions>
           <execution>
             <id>report-aggregate</id>

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/BaseWorkFlowTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/BaseWorkFlowTask.java
@@ -47,7 +47,7 @@ public abstract class BaseWorkFlowTask implements WorkFlowTask, BeanNameAware {
 		this.name = name;
 	}
 
-	protected String getParameterValue(WorkContext workContext, String parameterName) throws MissingParameterException {
+	public String getParameterValue(WorkContext workContext, String parameterName) throws MissingParameterException {
 		return new ObjectMapper()
 				.convertValue(
 						WorkContextDelegate.read(workContext, WorkContextDelegate.ProcessType.WORKFLOW_TASK_EXECUTION,

--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -16,6 +16,7 @@
             <assertj.version>3.17.2</assertj.version>
             <mockito.version>3.5.13</mockito.version>
             <slf4j.version>1.7.30</slf4j.version>
+            <lombok.version>1.18.24</lombok.version>
             <spring.framework.version>5.3.10</spring.framework.version>
             <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
             <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -51,7 +52,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>${lombok.version}</version>
         </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -12,6 +12,10 @@
         <properties>
             <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
             <java.version>11</java.version>
+            <junit.version>4.13.1</junit.version>
+            <assertj.version>3.17.2</assertj.version>
+            <mockito.version>3.5.13</mockito.version>
+            <slf4j.version>1.7.30</slf4j.version>
             <spring.framework.version>5.3.10</spring.framework.version>
             <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
             <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -42,13 +46,37 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>
         </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+                <scope>test</scope>
+            </dependency>
 	</dependencies>
 
     <build>

--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -68,7 +68,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
+                <artifactId>mockito-inline</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTask.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class OnboardingAssessmentTask extends BaseAssessmentTask {
 
-	private static final String INPUT = "INPUT";
+	static final String INPUT = "INPUT";
 
 	public OnboardingAssessmentTask(WorkFlowOption workflowOption) {
 		super(List.of(workflowOption));

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTask.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class OnboardingAssessmentTask extends BaseAssessmentTask {
 
-	static final String INPUT = "INPUT";
+	private static final String INPUT = "INPUT";
 
 	public OnboardingAssessmentTask(WorkFlowOption workflowOption) {
 		super(List.of(workflowOption));

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTask.java
@@ -15,6 +15,7 @@
  */
 package com.redhat.parodos.examples.simple;
 
+import com.redhat.parodos.examples.utils.RestUtils;
 import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
@@ -57,7 +58,7 @@ public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 			String urlString = getParameterValue(workContext, urlDefinedAtTaskCreation);
 			String payload = getParameterValue(workContext, PAYLOAD_PASSED_IN_FROM_SERVICE);
 			log.info("Running Task REST API Call: urlString: {} payload: {} ", urlString, payload);
-			ResponseEntity<String> result = executePost(urlString, payload);
+			ResponseEntity<String> result = RestUtils.executePost(urlString, payload);
 			if (result.getStatusCode().is2xxSuccessful()) {
 				log.info("Rest call completed: {}", result.getBody());
 				return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
@@ -68,11 +69,6 @@ public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 			log.error("There was an issue with the REST call: {}", e.getMessage());
 		}
 		return new DefaultWorkReport(WorkStatus.FAILED, workContext);
-	}
-
-	ResponseEntity<String> executePost(String urlString, String payload) {
-		RestTemplate restTemplate = new RestTemplate();
-		return restTemplate.postForEntity(urlString, payload, String.class);
 	}
 
 	@Override

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTask.java
@@ -15,11 +15,6 @@
  */
 package com.redhat.parodos.examples.simple;
 
-import java.util.List;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
-
 import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
@@ -29,6 +24,10 @@ import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
 
 /**
  * rest api task execution
@@ -58,8 +57,7 @@ public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 			String urlString = getParameterValue(workContext, urlDefinedAtTaskCreation);
 			String payload = getParameterValue(workContext, PAYLOAD_PASSED_IN_FROM_SERVICE);
 			log.info("Running Task REST API Call: urlString: {} payload: {} ", urlString, payload);
-			RestTemplate restTemplate = new RestTemplate();
-			ResponseEntity<String> result = restTemplate.postForEntity(urlString, payload, String.class);
+			ResponseEntity<String> result = executePost(urlString, payload);
 			if (result.getStatusCode().is2xxSuccessful()) {
 				log.info("Rest call completed: {}", result.getBody());
 				return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
@@ -68,9 +66,13 @@ public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 		}
 		catch (Exception e) {
 			log.error("There was an issue with the REST call: {}", e.getMessage());
-
 		}
 		return new DefaultWorkReport(WorkStatus.FAILED, workContext);
+	}
+
+	ResponseEntity<String> executePost(String urlString, String payload) {
+		RestTemplate restTemplate = new RestTemplate();
+		return restTemplate.postForEntity(urlString, payload, String.class);
 	}
 
 	@Override

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTask.java
@@ -46,57 +46,58 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class SecureAPIGetTestTask extends BaseInfrastructureWorkFlowTask {
 
-    public static final String SECURED_URL = "SECURED_URL";
+	public static final String SECURED_URL = "SECURED_URL";
 
-    public static final String USERNAME = "USERNAME";
+	public static final String USERNAME = "USERNAME";
 
-    public static final String PASSWORD = "PASSWORD";
+	public static final String PASSWORD = "PASSWORD";
 
-    /**
-     * Executed by the InfrastructureTask engine as part of the Workflow
-     */
-    public WorkReport execute(WorkContext workContext) {
-        try {
-            String urlString = getParameterValue(workContext, SECURED_URL);
-            String username = getParameterValue(workContext, USERNAME);
-            String password = getParameterValue(workContext, PASSWORD);
-            log.info("Calling: urlString: {} username: {}", urlString, username);
-            ResponseEntity<String> result = RestUtils.restExchange(urlString, username, password);
-            if (result.getStatusCode().is2xxSuccessful()) {
-                log.info("Rest call completed: {}", result.getBody());
-                return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
-            }
-            log.error("Call to the API was not successful. Response: {}", result.getStatusCode());
-        } catch (Exception e) {
-            log.error("There was an issue with the REST call: {}", e.getMessage());
+	/**
+	 * Executed by the InfrastructureTask engine as part of the Workflow
+	 */
+	public WorkReport execute(WorkContext workContext) {
+		try {
+			String urlString = getParameterValue(workContext, SECURED_URL);
+			String username = getParameterValue(workContext, USERNAME);
+			String password = getParameterValue(workContext, PASSWORD);
+			log.info("Calling: urlString: {} username: {}", urlString, username);
+			ResponseEntity<String> result = RestUtils.restExchange(urlString, username, password);
+			if (result.getStatusCode().is2xxSuccessful()) {
+				log.info("Rest call completed: {}", result.getBody());
+				return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+			}
+			log.error("Call to the API was not successful. Response: {}", result.getStatusCode());
+		}
+		catch (Exception e) {
+			log.error("There was an issue with the REST call: {}", e.getMessage());
 
-        }
-        return new DefaultWorkReport(WorkStatus.FAILED, workContext);
-    }
+		}
+		return new DefaultWorkReport(WorkStatus.FAILED, workContext);
+	}
 
-    HttpEntity<String> getRequestWithHeaders(String username, String password) {
-        String base64Creds = RestUtils.getBase64Creds(username, password);
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Basic " + base64Creds);
-        return new HttpEntity<String>(headers);
-    }
+	HttpEntity<String> getRequestWithHeaders(String username, String password) {
+		String base64Creds = RestUtils.getBase64Creds(username, password);
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Basic " + base64Creds);
+		return new HttpEntity<String>(headers);
+	}
 
-    @Override
-    public List<WorkFlowTaskParameter> getWorkFlowTaskParameters() {
-        return List.of(
-                WorkFlowTaskParameter.builder().key(SECURED_URL)
-                        .description("The URL of the Secured API you wish to call").optional(false)
-                        .type(WorkFlowTaskParameterType.URL).build(),
-                WorkFlowTaskParameter.builder().key(USERNAME).description("Please enter your username authentication")
-                        .optional(false).type(WorkFlowTaskParameterType.TEXT).build(),
-                WorkFlowTaskParameter.builder().key(PASSWORD)
-                        .description("Please enter your password for authentication (it will not be stored)")
-                        .optional(false).type(WorkFlowTaskParameterType.PASSWORD).build());
-    }
+	@Override
+	public List<WorkFlowTaskParameter> getWorkFlowTaskParameters() {
+		return List.of(
+				WorkFlowTaskParameter.builder().key(SECURED_URL)
+						.description("The URL of the Secured API you wish to call").optional(false)
+						.type(WorkFlowTaskParameterType.URL).build(),
+				WorkFlowTaskParameter.builder().key(USERNAME).description("Please enter your username authentication")
+						.optional(false).type(WorkFlowTaskParameterType.TEXT).build(),
+				WorkFlowTaskParameter.builder().key(PASSWORD)
+						.description("Please enter your password for authentication (it will not be stored)")
+						.optional(false).type(WorkFlowTaskParameterType.PASSWORD).build());
+	}
 
-    @Override
-    public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
-        return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
-    }
+	@Override
+	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
+		return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
+	}
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTask.java
@@ -17,6 +17,8 @@ package com.redhat.parodos.examples.simple;
 
 import java.util.Base64;
 import java.util.List;
+
+import com.redhat.parodos.examples.utils.RestUtils;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -44,73 +46,57 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class SecureAPIGetTestTask extends BaseInfrastructureWorkFlowTask {
 
-	public static final String SECURED_URL = "SECURED_URL";
+    public static final String SECURED_URL = "SECURED_URL";
 
-	public static final String USERNAME = "USERNAME";
+    public static final String USERNAME = "USERNAME";
 
-	public static final String PASSWORD = "PASSWORD";
+    public static final String PASSWORD = "PASSWORD";
 
-	/**
-	 * Executed by the InfrastructureTask engine as part of the Workflow
-	 */
-	public WorkReport execute(WorkContext workContext) {
-		try {
-			String urlString = getParameterValue(workContext, SECURED_URL);
-			String username = getParameterValue(workContext, USERNAME);
-			String password = getParameterValue(workContext, PASSWORD);
-			log.info("Calling: urlString: {} username: {}", urlString, username);
-			ResponseEntity<String> result = restExchange(urlString, username, password);
-			if (result.getStatusCode().is2xxSuccessful()) {
-				log.info("Rest call completed: {}", result.getBody());
-				return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
-			}
-			log.error("Call to the API was not successful. Response: {}", result.getStatusCode());
-		}
-		catch (Exception e) {
-			log.error("There was an issue with the REST call: {}", e.getMessage());
+    /**
+     * Executed by the InfrastructureTask engine as part of the Workflow
+     */
+    public WorkReport execute(WorkContext workContext) {
+        try {
+            String urlString = getParameterValue(workContext, SECURED_URL);
+            String username = getParameterValue(workContext, USERNAME);
+            String password = getParameterValue(workContext, PASSWORD);
+            log.info("Calling: urlString: {} username: {}", urlString, username);
+            ResponseEntity<String> result = RestUtils.restExchange(urlString, username, password);
+            if (result.getStatusCode().is2xxSuccessful()) {
+                log.info("Rest call completed: {}", result.getBody());
+                return new DefaultWorkReport(WorkStatus.COMPLETED, workContext);
+            }
+            log.error("Call to the API was not successful. Response: {}", result.getStatusCode());
+        } catch (Exception e) {
+            log.error("There was an issue with the REST call: {}", e.getMessage());
 
-		}
-		return new DefaultWorkReport(WorkStatus.FAILED, workContext);
-	}
+        }
+        return new DefaultWorkReport(WorkStatus.FAILED, workContext);
+    }
 
-	ResponseEntity<String> restExchange(String urlString, String username, String password) {
-		RestTemplate restTemplate = new RestTemplate();
-		ResponseEntity<String> result = restTemplate.exchange(urlString, HttpMethod.GET,
-				getRequestWithHeaders(username, password), String.class);
-		return result;
-	}
+    HttpEntity<String> getRequestWithHeaders(String username, String password) {
+        String base64Creds = RestUtils.getBase64Creds(username, password);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Basic " + base64Creds);
+        return new HttpEntity<String>(headers);
+    }
 
-	HttpEntity<String> getRequestWithHeaders(String username, String password) {
-		String base64Creds = getBase64Creds(username, password);
-		HttpHeaders headers = new HttpHeaders();
-		headers.add("Authorization", "Basic " + base64Creds);
-		return new HttpEntity<String>(headers);
-	}
+    @Override
+    public List<WorkFlowTaskParameter> getWorkFlowTaskParameters() {
+        return List.of(
+                WorkFlowTaskParameter.builder().key(SECURED_URL)
+                        .description("The URL of the Secured API you wish to call").optional(false)
+                        .type(WorkFlowTaskParameterType.URL).build(),
+                WorkFlowTaskParameter.builder().key(USERNAME).description("Please enter your username authentication")
+                        .optional(false).type(WorkFlowTaskParameterType.TEXT).build(),
+                WorkFlowTaskParameter.builder().key(PASSWORD)
+                        .description("Please enter your password for authentication (it will not be stored)")
+                        .optional(false).type(WorkFlowTaskParameterType.PASSWORD).build());
+    }
 
-	String getBase64Creds(String username, String password) {
-		String plainCreds = username + ":" + password;
-		byte[] plainCredsBytes = plainCreds.getBytes();
-		byte[] base64CredsBytes = Base64.getEncoder().encode(plainCredsBytes);
-		String base64Creds = new String(base64CredsBytes);
-		return base64Creds;
-	}
-
-	@Override
-	public List<WorkFlowTaskParameter> getWorkFlowTaskParameters() {
-		return List.of(
-				WorkFlowTaskParameter.builder().key(SECURED_URL)
-						.description("The URL of the Secured API you wish to call").optional(false)
-						.type(WorkFlowTaskParameterType.URL).build(),
-				WorkFlowTaskParameter.builder().key(USERNAME).description("Please enter your username authentication")
-						.optional(false).type(WorkFlowTaskParameterType.TEXT).build(),
-				WorkFlowTaskParameter.builder().key(PASSWORD)
-						.description("Please enter your password for authentication (it will not be stored)")
-						.optional(false).type(WorkFlowTaskParameterType.PASSWORD).build());
-	}
-
-	@Override
-	public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
-		return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
-	}
+    @Override
+    public List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
+        return List.of(WorkFlowTaskOutput.HTTP2XX, WorkFlowTaskOutput.OTHER);
+    }
 
 }

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/utils/RestUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/utils/RestUtils.java
@@ -1,0 +1,86 @@
+package com.redhat.parodos.examples.utils;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Base64;
+import java.util.Map;
+
+/**
+ * RestUtils is an utility class. All its methods must be declared as static so they can't
+ * be overridden.
+ */
+public final class RestUtils {
+
+	/**
+	 * The constructor is private so it'll prevent instantiation.
+	 * @throws UnsupportedOperationException
+	 */
+	private RestUtils() {
+		throw new UnsupportedOperationException("Suppress default constructor for non instantiability");
+	}
+
+	/**
+	 * Create a new resource by POSTing the given payload to the URL, and returns the
+	 * response as ResponseEntity.
+	 * @see org.springframework.web.client.RestTemplate#postForEntity(URI, Object, Class)
+	 * @param urlString the URL
+	 * @param payload object to post
+	 * @return @see org.springframework.http.ResponseEntity
+	 */
+	public static ResponseEntity<String> executePost(String urlString, String payload) {
+		RestTemplate restTemplate = new RestTemplate();
+		return restTemplate.postForEntity(urlString, payload, String.class);
+	}
+
+	/**
+	 * Execute the GET HTTP method to the given URL, writing the given request entity to
+	 * the request, and returns the response as ResponseEntity.
+	 *
+	 * @see org.springframework.web.client.RestTemplate#exchange(String, HttpMethod,
+	 * HttpEntity, Class, Object...)
+	 * @param urlString the URL
+	 * @param username the username
+	 * @param password the password
+	 * @return @see org.springframework.http.ResponseEntity
+	 */
+	public static ResponseEntity<String> restExchange(String urlString, String username, String password) {
+		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<String> result = restTemplate.exchange(urlString, HttpMethod.GET,
+				getRequestWithHeaders(username, password), String.class);
+		return result;
+	}
+
+	/**
+	 * Creates a new HttpHeader and set the Authorization object according to @see
+	 * getBase64Creds
+	 * @param username the username
+	 * @param password the password
+	 * @return the @see org.springframework.http.HttpEntity
+	 */
+	public static HttpEntity<String> getRequestWithHeaders(String username, String password) {
+		String base64Creds = getBase64Creds(username, password);
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Basic " + base64Creds);
+		return new HttpEntity<>(headers);
+	}
+
+	/**
+	 * Generates a Base64 encoding of username:password string
+	 * @param username the username
+	 * @param password the password
+	 * @return the Base64 encoded string
+	 */
+	public static String getBase64Creds(String username, String password) {
+		String plainCreds = username + ":" + password;
+		byte[] plainCredsBytes = plainCreds.getBytes();
+		byte[] base64CredsBytes = Base64.getEncoder().encode(plainCredsBytes);
+		String base64Creds = new String(base64CredsBytes);
+		return base64Creds;
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseAssessmentTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseAssessmentTaskTest.java
@@ -1,0 +1,42 @@
+package com.redhat.parodos.examples.base;
+
+import com.redhat.parodos.workflow.option.WorkFlowOption;
+import com.redhat.parodos.workflow.task.WorkFlowTaskType;
+import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+public abstract class BaseAssessmentTaskTest {
+
+	/**
+	 * These are the options this AssessmentTasks can return
+	 */
+	private List<WorkFlowOption> workflowOptions;
+
+	private BaseAssessmentTask baseAssessmentTask;
+
+	@Before
+	public void setUp() {
+		this.baseAssessmentTask = getConcretePersonImplementation();
+	}
+
+	/**
+	 * @return new instance of non-abstract class extending BaseInfrastructureWorkFlowTask
+	 */
+	protected abstract BaseAssessmentTask getConcretePersonImplementation();
+
+	public List<WorkFlowOption> getWorkFlowOptions() {
+		return workflowOptions;
+	}
+
+	public WorkFlowTaskType getType() {
+		return WorkFlowTaskType.ASSESSMENT;
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseInfrastructureWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseInfrastructureWorkFlowTaskTest.java
@@ -1,0 +1,35 @@
+package com.redhat.parodos.examples.base;
+
+import com.redhat.parodos.workflow.task.WorkFlowTaskType;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflows.workflow.WorkFlow;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+public abstract class BaseInfrastructureWorkFlowTaskTest {
+
+	protected final static String workflowTestName = "TestName";
+
+	private BaseInfrastructureWorkFlowTask baseInfrastructureWorkFlowTask;
+
+	@Before
+	public void setUp() {
+		this.baseInfrastructureWorkFlowTask = getConcretePersonImplementation();
+	}
+
+	/**
+	 * @return new instance of non-abstract class extending BaseInfrastructureWorkFlowTask
+	 */
+	protected abstract BaseInfrastructureWorkFlowTask getConcretePersonImplementation();
+
+	private WorkFlowTaskType type = WorkFlowTaskType.INFRASTRUCTURE;
+
+	public WorkFlow getWorkFlowChecker() {
+		WorkFlow testWorkflow = Mockito.mock(WorkFlow.class);
+		when(testWorkflow.getName()).thenReturn(workflowTestName);
+		return testWorkflow;
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseWorkFlowCheckerTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/base/BaseWorkFlowCheckerTaskTest.java
@@ -1,0 +1,33 @@
+package com.redhat.parodos.examples.base;
+
+import com.redhat.parodos.workflow.option.WorkFlowOption;
+import com.redhat.parodos.workflow.task.WorkFlowTaskType;
+import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
+import org.junit.Before;
+
+import java.util.List;
+
+public abstract class BaseWorkFlowCheckerTaskTest {
+
+	/**
+	 * These are the options this AssessmentTasks can return
+	 */
+	private List<WorkFlowOption> workflowOptions;
+
+	private BaseWorkFlowCheckerTask baseWorkFlowCheckerTask;
+
+	@Before
+	public void setUp() {
+		this.baseWorkFlowCheckerTask = getConcretePersonImplementation();
+	}
+
+	/**
+	 * @return new instance of non-abstract class extending BaseWorkFlowCheckerTaskTest
+	 */
+	protected abstract BaseWorkFlowCheckerTask getConcretePersonImplementation();
+
+	public WorkFlowTaskType getType() {
+		return WorkFlowTaskType.CHECKER;
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/continued/complex/MockApprovalWorkFlowCheckerTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/continued/complex/MockApprovalWorkFlowCheckerTaskTest.java
@@ -1,0 +1,73 @@
+package com.redhat.parodos.examples.continued.complex;
+
+import com.redhat.parodos.examples.base.BaseWorkFlowCheckerTaskTest;
+import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.checker.BaseWorkFlowCheckerTask;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Mock Approval WorkFlow Checker Task execution test
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public class MockApprovalWorkFlowCheckerTaskTest extends BaseWorkFlowCheckerTaskTest {
+
+	MockApprovalWorkFlowCheckerTask mockApprovalWorkFlowCheckerTask;
+
+	@Before
+	public void setUp() {
+		mockApprovalWorkFlowCheckerTask = spy((MockApprovalWorkFlowCheckerTask) getConcretePersonImplementation());
+	}
+
+	@Override
+	protected BaseWorkFlowCheckerTask getConcretePersonImplementation() {
+		return new MockApprovalWorkFlowCheckerTask();
+	}
+
+	@Test
+	public void checkWorkFlowStatus() {
+		// given
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+
+		// when
+		WorkReport workReport = mockApprovalWorkFlowCheckerTask.checkWorkFlowStatus(workContext);
+		assertNotNull(workReport);
+		assertEquals(WorkStatus.COMPLETED, workReport.getStatus());
+		assertNull(workReport.getError());
+	}
+
+	@Test
+	public void getWorkFlowTaskParameters() {
+		// when
+		List<WorkFlowTaskParameter> workFlowTaskParameters = mockApprovalWorkFlowCheckerTask
+				.getWorkFlowTaskParameters();
+
+		// then
+		assertNotNull(workFlowTaskParameters);
+		assertEquals(0, workFlowTaskParameters.size());
+	}
+
+	@Test
+	public void getWorkFlowTaskOutputs() {
+		// when
+		List<WorkFlowTaskOutput> workFlowTaskOutputs = mockApprovalWorkFlowCheckerTask.getWorkFlowTaskOutputs();
+
+		// then
+		assertNotNull(workFlowTaskOutputs);
+		assertEquals(0, workFlowTaskOutputs.size());
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTaskTest.java
@@ -1,0 +1,87 @@
+package com.redhat.parodos.examples.continued.complex;
+
+import com.redhat.parodos.examples.base.BaseAssessmentTaskTest;
+import com.redhat.parodos.workflow.context.WorkContextDelegate;
+import com.redhat.parodos.workflow.option.WorkFlowOption;
+import com.redhat.parodos.workflow.option.WorkFlowOptions;
+import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
+import com.redhat.parodos.workflows.work.DefaultWorkReport;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Onboarding Assessment Task execution test
+ *
+ * @author Gloria Ciavarrini (GitHub: gciavarrini)
+ */
+public class OnboardingAssessmentTaskTest extends BaseAssessmentTaskTest {
+
+	private OnboardingAssessmentTask onboardingAssessmentTask;
+
+	private WorkFlowOption workflowOption;
+
+	@Before
+	public void setUp() {
+
+		workflowOption = new WorkFlowOption.Builder("identifier", "workflowName")
+				.setDescription("a test workflow option").displayName("WorkflowOption_A").addToDetails("Other details")
+				.build();
+		onboardingAssessmentTask = spy((OnboardingAssessmentTask) getConcretePersonImplementation());
+	}
+
+	@Override
+	protected BaseAssessmentTask getConcretePersonImplementation() {
+		return new OnboardingAssessmentTask(workflowOption);
+	}
+
+	@Test
+	public void execute() {
+		// given
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+		WorkReport workReport = onboardingAssessmentTask.execute(workContext);
+
+		// then
+		assertNotNull(workReport);
+		assertEquals(WorkStatus.COMPLETED, workReport.getStatus());
+		assertNull(workReport.getError());
+	}
+
+	@Test
+	public void getWorkFlowTaskParameters() {
+		// when
+		List<WorkFlowTaskParameter> workFlowTaskParameters = onboardingAssessmentTask.getWorkFlowTaskParameters();
+
+		// then
+		assertNotNull(workFlowTaskParameters);
+		assertEquals(1, workFlowTaskParameters.size());
+		assertEquals(OnboardingAssessmentTask.INPUT, workFlowTaskParameters.get(0).getKey());
+		assertEquals("Enter some information to use for the Assessment to determine if they can onboard",
+				workFlowTaskParameters.get(0).getDescription());
+		assertEquals(WorkFlowTaskParameterType.TEXT, workFlowTaskParameters.get(0).getType());
+	}
+
+	@Test
+	public void getWorkFlowTaskOutputs() {
+		// when
+		List<WorkFlowTaskOutput> workFlowTaskOutputs = onboardingAssessmentTask.getWorkFlowTaskOutputs();
+
+		// then
+		assertNotNull(workFlowTaskOutputs);
+		assertEquals(0, workFlowTaskOutputs.size());
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/continued/complex/OnboardingAssessmentTaskTest.java
@@ -1,14 +1,11 @@
 package com.redhat.parodos.examples.continued.complex;
 
 import com.redhat.parodos.examples.base.BaseAssessmentTaskTest;
-import com.redhat.parodos.workflow.context.WorkContextDelegate;
 import com.redhat.parodos.workflow.option.WorkFlowOption;
-import com.redhat.parodos.workflow.option.WorkFlowOptions;
 import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.assessment.BaseAssessmentTask;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
-import com.redhat.parodos.workflows.work.DefaultWorkReport;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
@@ -33,6 +30,8 @@ public class OnboardingAssessmentTaskTest extends BaseAssessmentTaskTest {
 	private OnboardingAssessmentTask onboardingAssessmentTask;
 
 	private WorkFlowOption workflowOption;
+
+	private static final String INPUT = "INPUT";
 
 	@Before
 	public void setUp() {
@@ -68,7 +67,7 @@ public class OnboardingAssessmentTaskTest extends BaseAssessmentTaskTest {
 		// then
 		assertNotNull(workFlowTaskParameters);
 		assertEquals(1, workFlowTaskParameters.size());
-		assertEquals(OnboardingAssessmentTask.INPUT, workFlowTaskParameters.get(0).getKey());
+		assertEquals(INPUT, workFlowTaskParameters.get(0).getKey());
 		assertEquals("Enter some information to use for the Assessment to determine if they can onboard",
 				workFlowTaskParameters.get(0).getDescription());
 		assertEquals(WorkFlowTaskParameterType.TEXT, workFlowTaskParameters.get(0).getType());

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/LoggingWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/LoggingWorkFlowTaskTest.java
@@ -1,0 +1,94 @@
+package com.redhat.parodos.examples.simple;
+
+import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
+import com.redhat.parodos.workflow.consts.WorkFlowConstants;
+import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Logging WorkFlow Task execution test
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public class LoggingWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest {
+
+	private BaseInfrastructureWorkFlowTask loggingWorkFlowTask;
+
+	@Before
+	public void setUp() {
+		loggingWorkFlowTask = getConcretePersonImplementation();
+	}
+
+	@Test
+	public void executeNoChecker() {
+		// given
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+
+		// when
+		WorkReport workReport = loggingWorkFlowTask.execute(workContext);
+
+		// then
+		assertNull(loggingWorkFlowTask.getWorkFlowChecker());
+		assertEquals(WorkStatus.COMPLETED, workReport.getStatus());
+		Mockito.verifyNoInteractions(workContext);
+	}
+
+	@Test
+	public void executeWithChecker() {
+		// given
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+		loggingWorkFlowTask.setWorkFlowChecker(getWorkFlowChecker());
+
+		// when
+		WorkReport execute = loggingWorkFlowTask.execute(workContext);
+
+		// then
+		assertNotNull(loggingWorkFlowTask.getWorkFlowChecker());
+		assertEquals(WorkStatus.COMPLETED, execute.getStatus());
+		Mockito.verify(workContext, Mockito.times(1)).put(WorkFlowConstants.WORKFLOW_CHECKER_ID, workflowTestName);
+		Mockito.verifyNoMoreInteractions(workContext);
+	}
+
+	@Test
+	public void getWorkFlowTaskParameters() {
+		// when
+		List<WorkFlowTaskParameter> workFlowTaskParameters = loggingWorkFlowTask.getWorkFlowTaskParameters();
+
+		// then
+		assertNotNull(loggingWorkFlowTask.getWorkFlowTaskParameters());
+		assertEquals(1, workFlowTaskParameters.size());
+		assertEquals(WorkFlowTaskParameterType.URL, workFlowTaskParameters.get(0).getType());
+		assertEquals("api-server", workFlowTaskParameters.get(0).getKey());
+		assertEquals("The api server", workFlowTaskParameters.get(0).getDescription());
+	}
+
+	@Test
+	public void testGetWorkFlowTaskOutputs() {
+		// when
+		List<WorkFlowTaskOutput> workFlowTaskOutputs = loggingWorkFlowTask.getWorkFlowTaskOutputs();
+		// then
+		assertNotNull(workFlowTaskOutputs);
+		assertEquals(1, workFlowTaskOutputs.size());
+		assertEquals(WorkFlowTaskOutput.OTHER, workFlowTaskOutputs.get(0));
+	}
+
+	@Override
+	protected BaseInfrastructureWorkFlowTask getConcretePersonImplementation() {
+		return new LoggingWorkFlowTask();
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTaskTest.java
@@ -1,0 +1,118 @@
+package com.redhat.parodos.examples.simple;
+
+import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static com.redhat.parodos.examples.simple.RestAPIWorkFlowTask.PAYLOAD_PASSED_IN_FROM_SERVICE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Rest API WorkFlow Task execution test
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest {
+
+	private RestAPIWorkFlowTask restAPIWorkflowTask;
+
+	private final String testUrlDefinedAtCreation = "Test_urlDefinedAtTaskCreation";
+
+	@Before
+	public void setUp() {
+		this.restAPIWorkflowTask = spy((RestAPIWorkFlowTask) getConcretePersonImplementation());
+
+		try {
+			doReturn("value_url").when(this.restAPIWorkflowTask).getParameterValue(Mockito.any(WorkContext.class),
+					eq(testUrlDefinedAtCreation));
+			doReturn("payload").when(this.restAPIWorkflowTask).getParameterValue(Mockito.any(WorkContext.class),
+					eq(PAYLOAD_PASSED_IN_FROM_SERVICE));
+
+		}
+		catch (MissingParameterException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	protected BaseInfrastructureWorkFlowTask getConcretePersonImplementation() {
+		return new RestAPIWorkFlowTask(testUrlDefinedAtCreation);
+	}
+
+	@Test
+	public void executeSuccess() {
+		// given
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+		doReturn(new ResponseEntity("body", HttpStatus.OK)).when(restAPIWorkflowTask).executePost(anyString(),
+				anyString());
+
+		// when
+		WorkReport workReport = restAPIWorkflowTask.execute(workContext);
+
+		// then
+		assertEquals(WorkStatus.COMPLETED, workReport.getStatus());
+	}
+
+	@Test
+	public void executeFail() {
+		// given
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+		doReturn(new ResponseEntity("body", HttpStatus.BAD_REQUEST)).when(restAPIWorkflowTask).executePost(anyString(),
+				anyString());
+
+		// when
+		WorkReport workReport = restAPIWorkflowTask.execute(workContext);
+
+		// then
+		assertEquals(WorkStatus.FAILED, workReport.getStatus());
+	}
+
+	@Test
+	public void testGetWorkFlowTaskParameters() {
+		// when
+		List<WorkFlowTaskParameter> workFlowTaskParameters = restAPIWorkflowTask.getWorkFlowTaskParameters();
+
+		// then
+		assertNotNull(workFlowTaskParameters);
+		assertEquals(2, workFlowTaskParameters.size());
+		assertEquals(testUrlDefinedAtCreation, workFlowTaskParameters.get(0).getKey());
+		assertEquals("The Url of the service (ie: https://httpbin.org/post",
+				workFlowTaskParameters.get(0).getDescription());
+		assertEquals(WorkFlowTaskParameterType.URL, workFlowTaskParameters.get(0).getType());
+		assertEquals(PAYLOAD_PASSED_IN_FROM_SERVICE, workFlowTaskParameters.get(1).getKey());
+		assertEquals("Json of what to provide for data. (ie: 'Hello!')",
+				workFlowTaskParameters.get(1).getDescription());
+		assertEquals(WorkFlowTaskParameterType.PASSWORD, workFlowTaskParameters.get(1).getType());
+	}
+
+	@Test
+	public void testGetWorkFlowTaskOutputs() {
+		// when
+		List<WorkFlowTaskOutput> workFlowTaskOutputs = restAPIWorkflowTask.getWorkFlowTaskOutputs();
+
+		// then
+		assertNotNull(workFlowTaskOutputs);
+		assertEquals(2, workFlowTaskOutputs.size());
+		assertEquals(WorkFlowTaskOutput.HTTP2XX, workFlowTaskOutputs.get(0));
+		assertEquals(WorkFlowTaskOutput.OTHER, workFlowTaskOutputs.get(1));
+	}
+
+}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTaskTest.java
@@ -1,0 +1,158 @@
+package com.redhat.parodos.examples.simple;
+
+import com.redhat.parodos.examples.base.BaseInfrastructureWorkFlowTaskTest;
+import com.redhat.parodos.workflow.exception.MissingParameterException;
+import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
+import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
+import com.redhat.parodos.workflows.work.WorkContext;
+import com.redhat.parodos.workflows.work.WorkReport;
+import com.redhat.parodos.workflows.work.WorkStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+import static com.redhat.parodos.examples.simple.RestAPIWorkFlowTask.PAYLOAD_PASSED_IN_FROM_SERVICE;
+import static com.redhat.parodos.examples.simple.SecureAPIGetTestTask.PASSWORD;
+import static com.redhat.parodos.examples.simple.SecureAPIGetTestTask.SECURED_URL;
+import static com.redhat.parodos.examples.simple.SecureAPIGetTestTask.USERNAME;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Secure API Get Test Task execution test
+ *
+ * @author Gloria Ciavarrini (Github: gciavarrini)
+ */
+
+public class SecureAPIGetTestTaskTest extends BaseInfrastructureWorkFlowTaskTest {
+
+	private SecureAPIGetTestTask secureAPIGetTestTask;
+
+	private final String testUrl = "test_url";
+
+	private final String testUsername = "test_username";
+
+	private final String testPassword = "test_password";
+
+	private final String expectedBase64Creds = "dGVzdF91c2VybmFtZTp0ZXN0X3Bhc3N3b3Jk";
+
+	@Before
+	public void setUp() {
+		this.secureAPIGetTestTask = spy((SecureAPIGetTestTask) getConcretePersonImplementation());
+		try {
+			doReturn(testUrl).when(this.secureAPIGetTestTask).getParameterValue(Mockito.any(WorkContext.class),
+					eq(SECURED_URL));
+			doReturn(testUsername).when(this.secureAPIGetTestTask).getParameterValue(Mockito.any(WorkContext.class),
+					eq(USERNAME));
+			doReturn(testPassword).when(this.secureAPIGetTestTask).getParameterValue(Mockito.any(WorkContext.class),
+					eq(PASSWORD));
+		}
+		catch (MissingParameterException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	protected BaseInfrastructureWorkFlowTask getConcretePersonImplementation() {
+		return new SecureAPIGetTestTask();
+	}
+
+	@Test
+	public void executeSuccess() {
+		// given
+
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+
+		doReturn(new ResponseEntity("body", HttpStatus.OK)).when(secureAPIGetTestTask).restExchange(eq(testUrl),
+				eq(testUsername), eq(testPassword));
+
+		// when
+		WorkReport workReport = secureAPIGetTestTask.execute(workContext);
+
+		// then
+		assertNull(secureAPIGetTestTask.getWorkFlowChecker());
+		assertEquals(WorkStatus.COMPLETED, workReport.getStatus());
+		Mockito.verifyNoInteractions(workContext);
+	}
+
+	@Test
+	public void executeFail() {
+		// given
+		WorkContext workContext = Mockito.mock(WorkContext.class);
+
+		// when
+		WorkReport workReport = secureAPIGetTestTask.execute(workContext);
+
+		// then
+		assertNull(secureAPIGetTestTask.getWorkFlowChecker());
+		doReturn(new ResponseEntity("body", HttpStatus.BAD_REQUEST)).when(secureAPIGetTestTask)
+				.restExchange(eq(testUrl), eq(testUsername), eq(testPassword));
+
+		assertEquals(WorkStatus.FAILED, workReport.getStatus());
+		Mockito.verifyNoInteractions(workContext);
+	}
+
+	@Test
+	public void getRequestWithHeaders() {
+
+		// when
+		HttpEntity<String> requestWithHeaders = secureAPIGetTestTask.getRequestWithHeaders(testUsername, testPassword);
+
+		// then
+		assertNotNull(requestWithHeaders.getHeaders());
+		assertNull(requestWithHeaders.getBody());
+		assertNotNull(requestWithHeaders.getHeaders().get("Authorization"));
+		assertEquals(1, requestWithHeaders.getHeaders().get("Authorization").size());
+		assertEquals("Basic " + expectedBase64Creds, requestWithHeaders.getHeaders().get("Authorization").get(0));
+	}
+
+	@Test
+	public void getBase64Creds() {
+		String base64Creds = secureAPIGetTestTask.getBase64Creds(testUsername, testPassword);
+		assertNotNull(expectedBase64Creds, base64Creds);
+		assertEquals(expectedBase64Creds, base64Creds);
+	}
+
+	@Test
+	public void getWorkFlowTaskParameters() {
+		List<WorkFlowTaskParameter> workFlowTaskParameters = this.secureAPIGetTestTask.getWorkFlowTaskParameters();
+		// then
+		assertNotNull(workFlowTaskParameters);
+		assertEquals(3, workFlowTaskParameters.size());
+		assertEquals(SECURED_URL, workFlowTaskParameters.get(0).getKey());
+		assertEquals("The URL of the Secured API you wish to call", workFlowTaskParameters.get(0).getDescription());
+		assertEquals(WorkFlowTaskParameterType.URL, workFlowTaskParameters.get(0).getType());
+
+		assertEquals(USERNAME, workFlowTaskParameters.get(1).getKey());
+		assertEquals("Please enter your username authentication", workFlowTaskParameters.get(1).getDescription());
+		assertEquals(WorkFlowTaskParameterType.TEXT, workFlowTaskParameters.get(1).getType());
+
+		assertEquals(PASSWORD, workFlowTaskParameters.get(2).getKey());
+		assertEquals("Please enter your password for authentication (it will not be stored)",
+				workFlowTaskParameters.get(2).getDescription());
+		assertEquals(WorkFlowTaskParameterType.PASSWORD, workFlowTaskParameters.get(2).getType());
+	}
+
+	@Test
+	public void getWorkFlowTaskOutputs() {
+		// when
+		List<WorkFlowTaskOutput> workFlowTaskOutputs = secureAPIGetTestTask.getWorkFlowTaskOutputs();
+
+		// then
+		assertNotNull(workFlowTaskOutputs);
+		assertEquals(2, workFlowTaskOutputs.size());
+		assertEquals(WorkFlowTaskOutput.HTTP2XX, workFlowTaskOutputs.get(0));
+		assertEquals(WorkFlowTaskOutput.OTHER, workFlowTaskOutputs.get(1));
+	}
+
+}


### PR DESCRIPTION
This PR adds unit tests to workflow-example package.

Each example workflow java class has a coverage >= 80%.

![image](https://user-images.githubusercontent.com/15085664/222733435-c84333ed-70ec-407b-90d5-d29563ef14d3.png)

However, Configuration classes `SimpleWorkflowconfiguration` and `ComplexWorkFlowconfiguration` have **not** unit tests because they are supposed to be tested via integration tests.
That's why this PR excludes classes named `*Configuration.java` from coverage report.

The obtained coverage is:
![image](https://user-images.githubusercontent.com/15085664/222764451-0ef4c03d-bb5b-4f54-b0cc-25e5ae417806.png)




