### PR TITLE
run_examples script: Fix run_simple_flow example

### DIFF
--- a/workflow-examples/run_examples.sh
+++ b/workflow-examples/run_examples.sh
@@ -372,4 +372,16 @@ run_escalation_flow() {
   echo "                                                "
 }
 
-run_escalation_flow
+if [ $# -eq 0 ] || [ $1 = "escalation" ]; then
+  echo_blue "##### Running escalation flow #####"
+  run_escalation_flow
+elif [ $1 = "complex" ]; then
+  echo_blue "##### Running complex flow #####"
+  run_complex_flow
+elif [ $1 = "simple" ]; then
+echo_blue "##### Running simple flow #####"
+  run_simple_flow
+else
+  echo_red "##### Unsupported argument #####"
+  echo "Options: escalation (default) , complex, simple"
+fi

--- a/workflow-examples/run_examples.sh
+++ b/workflow-examples/run_examples.sh
@@ -111,26 +111,59 @@ wait_project_start() {
 
 
 run_simple_flow() {
-  echo "******** Running The Simple Sequence Flow ********"
+  wait_project_start
+  echo "Project is ✔️ on ${TARGET_URL}"
+  echo " "
+
+  echo_blue "******** Create Project ********"
+  echo "                                                "
+  PROJECT_ID=$(curl -X 'POST' -s \
+    "${TARGET_URL}/api/v1/projects" \
+    -H 'accept: */*' \
+    -H 'Authorization: Basic dGVzdDp0ZXN0' \
+    -H 'Content-Type: application/json' \
+    -d '{
+                 "name": "project-1",
+                 "description": "an example project"
+               }' | jq -r '.id')
+  [ ${#PROJECT_ID} -eq "36" ] || @fail "Project ID ${PROJECT_ID} is not present"
+  echo "Project id is " $(echo_green $PROJECT_ID)
+
+  echo_blue "******** Running The Simple Sequence Flow ********"
   echo "                                                  "
   echo "                                                  "
   workflow_id=$(get_workflow_id "simpleSequentialWorkFlowDefinition")
-  curl -X 'POST' -v \
+  curl -X 'POST' -s \
     "${TARGET_URL}/api/v1/workflows" \
     -H 'accept: */*' \
     -H 'Content-Type: application/json' \
+    -H 'Authorization: Basic dGVzdDp0ZXN0' \
     -d '{
-        "name": "simpleSequentialWorkFlow_INFRASTRUCTURE_WORKFLOW",
-        "tasks": []
-      }'
+        "projectId": "'$PROJECT_ID'",
+        "workFlowName": "simpleSequentialWorkFlow_INFRASTRUCTURE_WORKFLOW",
+        "workFlowTasks": [
+            {
+                            "name": "restCallTask",
+                            "arguments": [
+                              {
+                                "key": "url",
+                                "value": "https://httpbin.org/post"
+                              },
+                              {
+                                "key": "payload",
+                                "value": "'Hello!'"
+                              }
+                            ]
+                          }
+              ]
+            }'
   echo "                                                "
-  echo "******** Simple Sequence Flow Completed ********"
+  echo_blue "******** Simple Sequence Flow Completed ********"
   echo "                                                "
 }
 
 run_complex_flow() {
   echo "                                                "
-  set -x
   wait_project_start
   echo "Project is ✔️ on ${TARGET_URL}"
   echo " "

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTask.java
@@ -41,22 +41,17 @@ import java.util.List;
 @Slf4j
 public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 
-	private static final String PAYLOAD_PASSED_IN_FROM_SERVICE = "PAYLOAD_PASSED_IN_FROM_SERVICE";
+	private static final String PAYLOAD_KEY = "payload";
 
-	private String urlDefinedAtTaskCreation;
-
-	public RestAPIWorkFlowTask(String urlDefinedAtTaskCreation) {
-		super();
-		this.urlDefinedAtTaskCreation = urlDefinedAtTaskCreation;
-	}
+	private static final String URL_KEY = "url";
 
 	/**
 	 * Executed by the InfrastructureTask engine as part of the Workflow
 	 */
 	public WorkReport execute(WorkContext workContext) {
 		try {
-			String urlString = getParameterValue(workContext, urlDefinedAtTaskCreation);
-			String payload = getParameterValue(workContext, PAYLOAD_PASSED_IN_FROM_SERVICE);
+			String urlString = getParameterValue(workContext, URL_KEY);
+			String payload = getParameterValue(workContext, PAYLOAD_KEY);
 			log.info("Running Task REST API Call: urlString: {} payload: {} ", urlString, payload);
 			ResponseEntity<String> result = RestUtils.executePost(urlString, payload);
 			if (result.getStatusCode().is2xxSuccessful()) {
@@ -74,10 +69,10 @@ public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 	@Override
 	public List<WorkFlowTaskParameter> getWorkFlowTaskParameters() {
 		return List.of(
-				WorkFlowTaskParameter.builder().key(urlDefinedAtTaskCreation)
+				WorkFlowTaskParameter.builder().key(URL_KEY)
 						.description("The Url of the service (ie: https://httpbin.org/post").optional(false)
 						.type(WorkFlowTaskParameterType.URL).build(),
-				WorkFlowTaskParameter.builder().key(PAYLOAD_PASSED_IN_FROM_SERVICE)
+				WorkFlowTaskParameter.builder().key(PAYLOAD_KEY)
 						.description("Json of what to provide for data. (ie: 'Hello!')").optional(false)
 						.type(WorkFlowTaskParameterType.PASSWORD).build());
 	}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SimpleWorkFlowConfiguration.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SimpleWorkFlowConfiguration.java
@@ -34,12 +34,10 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SimpleWorkFlowConfiguration {
 
-	private final String URL_DEFINED_AT_CONFIGURATION_OF_TASK = "https://httpbin.org/post";
-
 	// START Sequential Example (WorkflowTasks and Workflow Definitions)
 	@Bean
-	RestAPIWorkFlowTask restCall() {
-		return new RestAPIWorkFlowTask(URL_DEFINED_AT_CONFIGURATION_OF_TASK);
+	RestAPIWorkFlowTask restCallTask() {
+		return new RestAPIWorkFlowTask();
 	}
 
 	@Bean
@@ -49,13 +47,13 @@ public class SimpleWorkFlowConfiguration {
 
 	@Bean(name = "simpleSequentialWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
 	@Infrastructure
-	WorkFlow simpleSequentialWorkFlowTask(@Qualifier("restCall") RestAPIWorkFlowTask restCall,
+	WorkFlow simpleSequentialWorkFlowTask(@Qualifier("restCallTask") RestAPIWorkFlowTask restCallTask,
 			@Qualifier("loggingTask") LoggingWorkFlowTask loggingTask) {
 		// @formatter:off
 		return SequentialFlow
 				.Builder.aNewSequentialFlow()
-				.named("simple Sequential WorkFlow")
-				.execute(restCall)
+				.named("simpleSequentialWorkFlow" + WorkFlowConstants.INFRASTRUCTURE_WORKFLOW)
+				.execute(restCallTask)
 				.then(loggingTask)
 				.build();
 		// @formatter:on

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/RestAPIWorkFlowTaskTest.java
@@ -38,9 +38,9 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 
 	private final String valuePayload = "value_payload";
 
-	private final String testUrlDefinedAtCreation = "Test_urlDefinedAtTaskCreation";
+	private static final String PAYLOAD_KEY = "payload";
 
-	private static final String PAYLOAD_PASSED_IN_FROM_SERVICE_TEST = "PAYLOAD_PASSED_IN_FROM_SERVICE";
+	private static final String URL_KEY = "url";
 
 	@Before
 	public void setUp() {
@@ -48,9 +48,9 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 
 		try {
 			doReturn(valueUrl).when(this.restAPIWorkflowTask).getParameterValue(Mockito.any(WorkContext.class),
-					eq(testUrlDefinedAtCreation));
+					eq(URL_KEY));
 			doReturn(valuePayload).when(this.restAPIWorkflowTask).getParameterValue(Mockito.any(WorkContext.class),
-					eq(PAYLOAD_PASSED_IN_FROM_SERVICE_TEST));
+					eq(PAYLOAD_KEY));
 
 		}
 		catch (MissingParameterException e) {
@@ -60,7 +60,7 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 
 	@Override
 	protected BaseInfrastructureWorkFlowTask getConcretePersonImplementation() {
-		return new RestAPIWorkFlowTask(testUrlDefinedAtCreation);
+		return new RestAPIWorkFlowTask();
 	}
 
 	@Test
@@ -103,11 +103,11 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 		// then
 		assertNotNull(workFlowTaskParameters);
 		assertEquals(2, workFlowTaskParameters.size());
-		assertEquals(testUrlDefinedAtCreation, workFlowTaskParameters.get(0).getKey());
+		assertEquals(URL_KEY, workFlowTaskParameters.get(0).getKey());
 		assertEquals("The Url of the service (ie: https://httpbin.org/post",
 				workFlowTaskParameters.get(0).getDescription());
 		assertEquals(WorkFlowTaskParameterType.URL, workFlowTaskParameters.get(0).getType());
-		assertEquals(PAYLOAD_PASSED_IN_FROM_SERVICE_TEST, workFlowTaskParameters.get(1).getKey());
+		assertEquals(PAYLOAD_KEY, workFlowTaskParameters.get(1).getKey());
 		assertEquals("Json of what to provide for data. (ie: 'Hello!')",
 				workFlowTaskParameters.get(1).getDescription());
 		assertEquals(WorkFlowTaskParameterType.PASSWORD, workFlowTaskParameters.get(1).getType());


### PR DESCRIPTION
This includes the following changes:
* Get the PROJECT_ID and adding it the the Workflow execution
* Change parametes: name to workFlowName & tasks to workFlowTasks
* Add workflow task arguments to restCallTask
* Fix RestAPIWorkFlowTask use the right key for WorkFlowTaskParameters