### PR TITLE
Extract getBase64Creds to a shared module

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/utils/CredUtils.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/utils/CredUtils.java
@@ -1,0 +1,21 @@
+package com.redhat.parodos.workflow.utils;
+
+import java.util.Base64;
+
+public class CredUtils {
+
+	/**
+	 * Generates a Base64 encoding of username:password string
+	 * @param username the username
+	 * @param password the password
+	 * @return the Base64 encoded string
+	 */
+	public static String getBase64Creds(String username, String password) {
+		String plainCreds = username + ":" + password;
+		byte[] plainCredsBytes = plainCreds.getBytes();
+		byte[] base64CredsBytes = Base64.getEncoder().encode(plainCredsBytes);
+		String base64Creds = new String(base64CredsBytes);
+		return base64Creds;
+	}
+
+}

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/utils/CredUtilsTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/utils/CredUtilsTest.java
@@ -1,0 +1,20 @@
+package com.redhat.parodos.workflow.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CredUtilsTest {
+
+	@Test
+	public void testGetBase64Creds() {
+		String username = "user123";
+		String password = "pass456";
+		String expectedBase64Creds = "dXNlcjEyMzpwYXNzNDU2";
+
+		String actualBase64Creds = CredUtils.getBase64Creds(username, password);
+
+		assertEquals(expectedBase64Creds, actualBase64Creds);
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTask.java
@@ -15,16 +15,14 @@
  */
 package com.redhat.parodos.examples.simple;
 
-import java.util.Base64;
 import java.util.List;
 
 import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.utils.CredUtils;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
 import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
@@ -76,7 +74,7 @@ public class SecureAPIGetTestTask extends BaseInfrastructureWorkFlowTask {
 	}
 
 	HttpEntity<String> getRequestWithHeaders(String username, String password) {
-		String base64Creds = RestUtils.getBase64Creds(username, password);
+		String base64Creds = CredUtils.getBase64Creds(username, password);
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Authorization", "Basic " + base64Creds);
 		return new HttpEntity<String>(headers);

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/utils/RestUtils.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/utils/RestUtils.java
@@ -1,5 +1,6 @@
 package com.redhat.parodos.examples.utils;
 
+import com.redhat.parodos.workflow.utils.CredUtils;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -7,8 +8,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
-import java.util.Base64;
-import java.util.Map;
 
 /**
  * RestUtils is an utility class. All its methods must be declared as static so they can't
@@ -63,24 +62,10 @@ public final class RestUtils {
 	 * @return the @see org.springframework.http.HttpEntity
 	 */
 	public static HttpEntity<String> getRequestWithHeaders(String username, String password) {
-		String base64Creds = getBase64Creds(username, password);
+		String base64Creds = CredUtils.getBase64Creds(username, password);
 		HttpHeaders headers = new HttpHeaders();
 		headers.add("Authorization", "Basic " + base64Creds);
 		return new HttpEntity<>(headers);
-	}
-
-	/**
-	 * Generates a Base64 encoding of username:password string
-	 * @param username the username
-	 * @param password the password
-	 * @return the Base64 encoded string
-	 */
-	public static String getBase64Creds(String username, String password) {
-		String plainCreds = username + ":" + password;
-		byte[] plainCredsBytes = plainCreds.getBytes();
-		byte[] base64CredsBytes = Base64.getEncoder().encode(plainCredsBytes);
-		String base64Creds = new String(base64CredsBytes);
-		return base64Creds;
 	}
 
 }

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/SecureAPIGetTestTaskTest.java
@@ -7,6 +7,7 @@ import com.redhat.parodos.workflow.task.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.infrastructure.BaseInfrastructureWorkFlowTask;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
+import com.redhat.parodos.workflow.utils.CredUtils;
 import com.redhat.parodos.workflows.work.WorkContext;
 import com.redhat.parodos.workflows.work.WorkReport;
 import com.redhat.parodos.workflows.work.WorkStatus;
@@ -20,12 +21,8 @@ import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
-import static com.redhat.parodos.examples.simple.SecureAPIGetTestTask.PASSWORD;
-import static com.redhat.parodos.examples.simple.SecureAPIGetTestTask.SECURED_URL;
-import static com.redhat.parodos.examples.simple.SecureAPIGetTestTask.USERNAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static com.redhat.parodos.examples.simple.SecureAPIGetTestTask.*;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -122,7 +119,7 @@ public class SecureAPIGetTestTaskTest extends BaseInfrastructureWorkFlowTaskTest
 
 	@Test
 	public void getBase64Creds() {
-		String base64Creds = RestUtils.getBase64Creds(testUsername, testPassword);
+		String base64Creds = CredUtils.getBase64Creds(testUsername, testPassword);
 		assertNotNull(expectedBase64Creds, base64Creds);
 		assertEquals(expectedBase64Creds, base64Creds);
 	}

--- a/workflow-service/src/test/java/com/redhat/parodos/ControllerMockClient.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/ControllerMockClient.java
@@ -1,15 +1,10 @@
 package com.redhat.parodos;
 
-import com.redhat.parodos.examples.utils.RestUtils;
+import com.redhat.parodos.workflow.utils.CredUtils;
 import lombok.Getter;
 import lombok.Setter;
-import org.junit.jupiter.params.shadow.com.univocity.parsers.annotations.Headers;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-
-import java.util.Base64;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -59,11 +54,11 @@ public abstract class ControllerMockClient {
 	}
 
 	public String invalidCredentials() {
-		return String.format("Basic %s", RestUtils.getBase64Creds("foo", "bar"));
+		return String.format("Basic %s", CredUtils.getBase64Creds("foo", "bar"));
 	}
 
 	public String credentials() {
-		return String.format("Basic %s", RestUtils.getBase64Creds(this.getValidUser(), this.getValidPassword()));
+		return String.format("Basic %s", CredUtils.getBase64Creds(this.getValidUser(), this.getValidPassword()));
 	}
 
 }


### PR DESCRIPTION
In order to simplify project dependencies, the explicit dependency from `workflow-service` module to `workflow-example` is being reduced by extracting to a shared module the required functionality.