### PR TITLE
Remove redundant dependency

### DIFF
--- a/workflow-service/pom.xml
+++ b/workflow-service/pom.xml
@@ -68,10 +68,6 @@
             <artifactId>spring-ldap-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-ldap</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.unboundid</groupId>
             <artifactId>unboundid-ldapsdk</artifactId>
         </dependency>


### PR DESCRIPTION
The `spring-security-ldap` dependency was specified twice in the same pom.xml.