### PR TITLE
Add 'provided' scope to existing jars in examples

### DIFF
--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -47,21 +47,25 @@
             <groupId>dev.parodos</groupId>
             <artifactId>workflow-engine</artifactId>
             <version>${revision}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>dev.parodos</groupId>
             <artifactId>parodos-model-api</artifactId>
             <version>${revision}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Add 'provided' scope to existing jars in examples
    
In order to rely on jar versions as provided by the workflow server, there is a need to set the scope of those dependencies in workflow-examples/pom.xml as `provided`.
    
Signed-off-by: Moti Asayag <masayag@redhat.com>