### PR TITLE
Remove unused annotation

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/WorkflowServiceApplication.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/WorkflowServiceApplication.java
@@ -19,7 +19,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;


### PR DESCRIPTION
The ComponentScan annotation is implicitly declared by SpringBootApplication annotation.