### PR TITLE
Workflow-service: Parameters as jsonschema

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameter.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameter.java
@@ -27,6 +27,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 @Data
 @Builder
 @AllArgsConstructor
@@ -40,5 +42,15 @@ public class WorkFlowParameter {
 	private String description;
 
 	private boolean optional;
+
+	public Map<String, String> getAsJsonSchema() {
+		if (this.getType() == null) {
+			return Map.of();
+		}
+		Map<String, String> properties = this.getType().getAsJsonSchema();
+		properties.put("required", String.valueOf(!this.isOptional()));
+		properties.put("description", this.getDescription());
+		return properties;
+	}
 
 }

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterType.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterType.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.workflow.parameter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Workflow parameter type
  *
@@ -23,6 +26,38 @@ package com.redhat.parodos.workflow.parameter;
  */
 public enum WorkFlowParameterType {
 
-	PASSWORD, TEXT, EMAIL, DATE, NUMBER, URL
+	PASSWORD, TEXT, EMAIL, DATE, NUMBER, URL;
+
+	public Map<String, String> getAsJsonSchema() {
+		Map<String, String> properties = new HashMap<>();
+		switch (this) {
+			case PASSWORD:
+				properties.put("type", "string");
+				properties.put("format", "password");
+				break;
+			case TEXT:
+				properties.put("type", "string");
+				properties.put("format", "text");
+				break;
+			case EMAIL:
+				properties.put("type", "string");
+				properties.put("format", "email");
+				break;
+			case NUMBER:
+				properties.put("type", "number");
+				break;
+			case URL:
+				properties.put("type", "string");
+				properties.put("format", "url");
+				break;
+			case DATE:
+				properties.put("type", "string");
+				properties.put("format", "date");
+				break;
+			default:
+				throw new IllegalArgumentException("Invalid parameter type");
+		}
+		return properties;
+	}
 
 }

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/WorkFlowTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/WorkFlowTask.java
@@ -15,9 +15,13 @@
  */
 package com.redhat.parodos.workflow.task;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
 import com.redhat.parodos.workflows.work.Work;
 import lombok.NonNull;
@@ -50,6 +54,28 @@ public interface WorkFlowTask extends Work {
 	default List<WorkFlowTaskOutput> getWorkFlowTaskOutputs() {
 		return Collections.emptyList();
 
+	}
+
+	default HashMap<String, Map<String, String>> getAsJsonSchema() {
+		HashMap<String, Map<String, String>> result = new HashMap<>();
+		for (WorkFlowTaskParameter workFlowTaskParameter : this.getWorkFlowTaskParameters()) {
+			if (workFlowTaskParameter == null) {
+				continue;
+			}
+
+			if (workFlowTaskParameter.getType() == null) {
+				continue;
+			}
+
+			Map<String, String> properties = workFlowTaskParameter.getType().getAsJsonSchema();
+			properties.put("required", String.valueOf(!workFlowTaskParameter.isOptional()));
+			properties.put("description", workFlowTaskParameter.getDescription());
+			if (workFlowTaskParameter.getJsonSchemaOptions() != null) {
+				properties.putAll(workFlowTaskParameter.getJsonSchemaOptions());
+			}
+			result.put(workFlowTaskParameter.getKey(), properties);
+		}
+		return result;
 	}
 
 }

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameter.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameter.java
@@ -20,6 +20,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 /**
  * An input to a @see WorkFlowTask. The @see WorkFlowTaskParameterType is used by the UI
  * to render inputs to collect the values from users running the workflow
@@ -40,5 +42,7 @@ public class WorkFlowTaskParameter {
 	private boolean optional;
 
 	private WorkFlowTaskParameterType type;
+
+	private Map<String, String> JsonSchemaOptions;
 
 }

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterType.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterType.java
@@ -15,6 +15,9 @@
  */
 package com.redhat.parodos.workflow.task.parameter;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The supported types for a @see WorkFlowTaskParameter. A UI layer can render appropriate
  * components to collect/validate user inputs using these values
@@ -24,6 +27,38 @@ package com.redhat.parodos.workflow.task.parameter;
  */
 public enum WorkFlowTaskParameterType {
 
-	PASSWORD, TEXT, EMAIL, DATE, NUMBER, URL
+	PASSWORD, TEXT, EMAIL, DATE, NUMBER, URL;
+
+	public Map<String, String> getAsJsonSchema() {
+		Map<String, String> properties = new HashMap<>();
+		switch (this) {
+			case PASSWORD:
+				properties.put("type", "string");
+				properties.put("format", "password");
+				break;
+			case TEXT:
+				properties.put("type", "string");
+				properties.put("format", "text");
+				break;
+			case EMAIL:
+				properties.put("type", "string");
+				properties.put("format", "email");
+				break;
+			case NUMBER:
+				properties.put("type", "number");
+				break;
+			case URL:
+				properties.put("type", "string");
+				properties.put("format", "url");
+				break;
+			case DATE:
+				properties.put("type", "string");
+				properties.put("format", "date");
+				break;
+			default:
+				throw new IllegalArgumentException("Invalid parameter type");
+		}
+		return properties;
+	}
 
 }

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTest.java
@@ -1,0 +1,39 @@
+package com.redhat.parodos.workflow.parameter;
+
+import junit.framework.TestCase;
+
+import java.util.Map;
+
+public class WorkFlowParameterTest extends TestCase {
+
+	String key = "key";
+
+	String description = "key description";
+
+	public void testGetAsJsonSchemaWithValidData() {
+
+		// given
+		WorkFlowParameter parameters = WorkFlowParameter.builder().key(key).description(description)
+				.type(WorkFlowParameterType.TEXT).build();
+		// when
+		Map<String, String> result = parameters.getAsJsonSchema();
+		// then
+		assertNotNull(result);
+		assertEquals(result.size(), 4);
+		assertEquals(result.get("type"), "string");
+		assertEquals(result.get("description"), description);
+		assertEquals(result.get("format"), "text");
+		assertEquals(result.get("required"), "true");
+	}
+
+	public void testGetAsJsonSchemaWithoutType() {
+		// given
+		WorkFlowParameter parameters = WorkFlowParameter.builder().key(key).description(description).build();
+		// when
+		Map<String, String> result = parameters.getAsJsonSchema();
+		// then
+		assertNotNull(result);
+		assertEquals(result.size(), 0);
+	}
+
+}

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTypeTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTypeTest.java
@@ -1,0 +1,57 @@
+package com.redhat.parodos.workflow.parameter;
+
+import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameterType;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class WorkFlowParameterTypeTest extends TestCase {
+
+	@Test
+	public void testJsonSchema() {
+		WorkFlowParameterType[] inputValues = { WorkFlowParameterType.PASSWORD, WorkFlowParameterType.TEXT,
+				WorkFlowParameterType.EMAIL, WorkFlowParameterType.NUMBER, WorkFlowParameterType.URL,
+				WorkFlowParameterType.DATE };
+
+		List<Map<String, String>> outputs = new ArrayList<>();
+		for (WorkFlowParameterType inputValue : inputValues) {
+			outputs.add(inputValue.getAsJsonSchema());
+		}
+		assertEquals(inputValues.length, outputs.size());
+
+		Map<String, String> expectedPasswordOutput = new HashMap<>();
+		expectedPasswordOutput.put("type", "string");
+		expectedPasswordOutput.put("format", "password");
+		assertEquals(expectedPasswordOutput, outputs.get(0));
+
+		Map<String, String> expectedTextOutput = new HashMap<>();
+		expectedTextOutput.put("type", "string");
+		expectedTextOutput.put("format", "text");
+		assertEquals(expectedTextOutput, outputs.get(1));
+
+		Map<String, String> expectedEmailOutput = new HashMap<>();
+		expectedEmailOutput.put("type", "string");
+		expectedEmailOutput.put("format", "email");
+		assertEquals(expectedEmailOutput, outputs.get(2));
+
+		Map<String, String> expectedNumberOutput = new HashMap<>();
+		expectedNumberOutput.put("type", "number");
+		assertEquals(expectedNumberOutput, outputs.get(3));
+
+		Map<String, String> expectedURLOutput = new HashMap<>();
+		expectedURLOutput.put("type", "string");
+		expectedURLOutput.put("format", "url");
+		assertEquals(expectedURLOutput, outputs.get(4));
+
+		Map<String, String> expectedDateOutput = new HashMap<>();
+		expectedDateOutput.put("type", "string");
+		expectedDateOutput.put("format", "date");
+		assertEquals(expectedDateOutput, outputs.get(5));
+
+	}
+
+}

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterTypeTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterTypeTest.java
@@ -1,0 +1,56 @@
+package com.redhat.parodos.workflow.task.parameter;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class WorkFlowTaskParameterTypeTest extends TestCase {
+
+	@Test
+	public void testJsonSchema() {
+		WorkFlowTaskParameterType[] inputValues = { WorkFlowTaskParameterType.PASSWORD, WorkFlowTaskParameterType.TEXT,
+				WorkFlowTaskParameterType.EMAIL, WorkFlowTaskParameterType.NUMBER, WorkFlowTaskParameterType.URL,
+				WorkFlowTaskParameterType.DATE };
+
+		List<Map<String, String>> outputs = new ArrayList<>();
+		for (WorkFlowTaskParameterType inputValue : inputValues) {
+			outputs.add(inputValue.getAsJsonSchema());
+		}
+		assertEquals(inputValues.length, outputs.size());
+
+		Map<String, String> expectedPasswordOutput = new HashMap<>();
+		expectedPasswordOutput.put("type", "string");
+		expectedPasswordOutput.put("format", "password");
+		assertEquals(expectedPasswordOutput, outputs.get(0));
+
+		Map<String, String> expectedTextOutput = new HashMap<>();
+		expectedTextOutput.put("type", "string");
+		expectedTextOutput.put("format", "text");
+		assertEquals(expectedTextOutput, outputs.get(1));
+
+		Map<String, String> expectedEmailOutput = new HashMap<>();
+		expectedEmailOutput.put("type", "string");
+		expectedEmailOutput.put("format", "email");
+		assertEquals(expectedEmailOutput, outputs.get(2));
+
+		Map<String, String> expectedNumberOutput = new HashMap<>();
+		expectedNumberOutput.put("type", "number");
+		assertEquals(expectedNumberOutput, outputs.get(3));
+
+		Map<String, String> expectedURLOutput = new HashMap<>();
+		expectedURLOutput.put("type", "string");
+		expectedURLOutput.put("format", "url");
+		assertEquals(expectedURLOutput, outputs.get(4));
+
+		Map<String, String> expectedDateOutput = new HashMap<>();
+		expectedDateOutput.put("type", "string");
+		expectedDateOutput.put("format", "date");
+		assertEquals(expectedDateOutput, outputs.get(5));
+
+	}
+
+}

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/LoggingWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/LoggingWorkFlowTask.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * logging task execution
@@ -66,7 +67,8 @@ public class LoggingWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 				WorkFlowTaskParameter.builder().key("api-server").description("The api server")
 						.type(WorkFlowTaskParameterType.URL).optional(false).build(),
 				WorkFlowTaskParameter.builder().key("user-id").description("The user id")
-						.type(WorkFlowTaskParameterType.TEXT).optional(false).build());
+						.type(WorkFlowTaskParameterType.TEXT).optional(false)
+						.JsonSchemaOptions(Map.of("minLength", "1", "maxLength", "64")).build());
 	}
 
 	@Override

--- a/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTask.java
+++ b/workflow-examples/src/main/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTask.java
@@ -73,7 +73,7 @@ public class RestAPIWorkFlowTask extends BaseInfrastructureWorkFlowTask {
 						.type(WorkFlowTaskParameterType.URL).build(),
 				WorkFlowTaskParameter.builder().key(PAYLOAD_KEY)
 						.description("Json of what to provide for data. (ie: 'Hello!')").optional(false)
-						.type(WorkFlowTaskParameterType.PASSWORD).build(),
+						.type(WorkFlowTaskParameterType.TEXT).build(),
 				WorkFlowTaskParameter.builder().key("user-id").description("The user id")
 						.type(WorkFlowTaskParameterType.TEXT).optional(false).build());
 	}

--- a/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTaskTest.java
+++ b/workflow-examples/src/test/java/com/redhat/parodos/examples/simple/task/RestAPIWorkFlowTaskTest.java
@@ -110,7 +110,7 @@ public class RestAPIWorkFlowTaskTest extends BaseInfrastructureWorkFlowTaskTest 
 		assertEquals(PAYLOAD_KEY, workFlowTaskParameters.get(1).getKey());
 		assertEquals("Json of what to provide for data. (ie: 'Hello!')",
 				workFlowTaskParameters.get(1).getDescription());
-		assertEquals(WorkFlowTaskParameterType.PASSWORD, workFlowTaskParameters.get(1).getType());
+		assertEquals(WorkFlowTaskParameterType.TEXT, workFlowTaskParameters.get(1).getType());
 	}
 
 	@Test

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
@@ -18,11 +18,16 @@ package com.redhat.parodos.workflow.definition.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.redhat.parodos.workflow.parameter.WorkFlowParameter;
 import com.redhat.parodos.workflow.task.enums.WorkFlowTaskOutput;
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
-import java.util.List;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -58,12 +63,26 @@ public class WorkDefinitionResponseDTO {
 	private List<WorkDefinitionResponseDTO> works;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	private List parameters;
+	private Map<String, Map<String, String>> parameters;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<WorkFlowTaskOutput> outputs;
 
 	@JsonIgnore
 	private Integer numberOfWorkUnits;
+
+	public static class WorkDefinitionResponseDTOBuilder {
+
+		public WorkDefinitionResponseDTOBuilder parameterFromString(String parameters) {
+			if (parameters == null) {
+				return this;
+			}
+			this.parameters(WorkFlowDTOUtil.readStringAsObject(parameters,
+					new TypeReference<Map<String, Map<String, String>>>() {
+					}, Map.of()));
+			return this;
+		}
+
+	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
@@ -16,11 +16,14 @@
 package com.redhat.parodos.workflow.definition.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
+import com.redhat.parodos.workflow.util.WorkFlowDTOUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -56,9 +59,23 @@ public class WorkFlowDefinitionResponseDTO {
 	private Date modifyDate;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	private List<WorkFlowTaskParameter> parameters;
+	private Map<String, Map<String, String>> parameters;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<WorkDefinitionResponseDTO> works;
+
+	public static class WorkFlowDefinitionResponseDTOBuilder {
+
+		public WorkFlowDefinitionResponseDTOBuilder parameterFromString(String parameters) {
+			if (parameters == null) {
+				return this;
+			}
+			this.parameters(WorkFlowDTOUtil.readStringAsObject(parameters,
+					new TypeReference<Map<String, Map<String, String>>>() {
+					}, Map.of()));
+			return this;
+		}
+
+	}
 
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/converter/WorkFlowTaskDefinitionDTOConverter.java
@@ -49,10 +49,7 @@ public class WorkFlowTaskDefinitionDTOConverter
 				return WorkDefinitionResponseDTO.builder().id(workFlowTaskDefinition.getId().toString())
 						.name(workFlowTaskDefinition.getName())
 						.outputs(objectMapper.readValue(workFlowTaskDefinition.getOutputs(), new TypeReference<>() {
-						})).parameters(new ArrayList<>(objectMapper.readValue(workFlowTaskDefinition.getParameters(),
-								new TypeReference<List<WorkFlowTaskParameter>>() {
-								})))
-						.build();
+						})).parameterFromString(workFlowTaskDefinition.getParameters()).build();
 			}
 			catch (JsonProcessingException e) {
 				throw new WorkflowDefinitionException(e);

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/controller/WorkFlowDefinitionControllerTest.java
@@ -4,7 +4,6 @@ import com.redhat.parodos.ControllerMockClient;
 import com.redhat.parodos.workflow.definition.dto.WorkDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.dto.WorkFlowDefinitionResponseDTO;
 import com.redhat.parodos.workflow.definition.service.WorkFlowDefinitionServiceImpl;
-import com.redhat.parodos.workflow.task.parameter.WorkFlowTaskParameter;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -18,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.Map;
 import java.util.UUID;
 import java.util.List;
 
@@ -49,8 +49,7 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.jsonPath("$[0].name", Matchers.is(WFDefFoo.getName())))
 				.andExpect(MockMvcResultMatchers.jsonPath("$[0].works", Matchers.hasSize(1)))
 				.andExpect(MockMvcResultMatchers.jsonPath("$[0].works[0].name", Matchers.is("task1")))
-				.andExpect(MockMvcResultMatchers.jsonPath("$[0].works[0].parameters[0].key", Matchers.is("param1")))
-				.andExpect(MockMvcResultMatchers.jsonPath("$[0].works[0].parameters[0].description",
+				.andExpect(MockMvcResultMatchers.jsonPath("$[0].works[0].parameters.param1.description",
 						Matchers.is("param1")))
 				.andExpect(MockMvcResultMatchers.jsonPath("$[1].id", Matchers.is(WFDefBar.getId().toString())))
 				.andExpect(MockMvcResultMatchers.jsonPath("$[1].name", Matchers.is(WFDefBar.getName())));
@@ -84,9 +83,8 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 				.andExpect(MockMvcResultMatchers.jsonPath("$.name", Matchers.is(WFDef.getName())))
 				.andExpect(MockMvcResultMatchers.jsonPath("$.works", Matchers.hasSize(1)))
 				.andExpect(MockMvcResultMatchers.jsonPath("$.works[0].name", Matchers.is("task1")))
-				.andExpect(MockMvcResultMatchers.jsonPath("$.works[0].parameters[0].key", Matchers.is("param1")))
-				.andExpect(
-						MockMvcResultMatchers.jsonPath("$.works[0].parameters[0].description", Matchers.is("param1")));
+				.andExpect(MockMvcResultMatchers.jsonPath("$.works[0].parameters.param1.description",
+						Matchers.is("param1")));
 
 		// then
 		Mockito.verify(this.workFlowDefinitionService, Mockito.times(1)).getWorkFlowDefinitionById(WFDef.getId());
@@ -128,9 +126,9 @@ class WorkFlowDefinitionControllerTest extends ControllerMockClient {
 	}
 
 	private WorkDefinitionResponseDTO createSampleWorkFlowTaskDefinition(String name) {
+		String parameters = "{\"param1\": {\"description\": \"param1\"}}";
 		return WorkDefinitionResponseDTO.builder().id(UUID.randomUUID().toString()).name(name)
-				.parameters(List.of(WorkFlowTaskParameter.builder().key("param1").description("param1").build()))
-				.build();
+				.parameterFromString(parameters).build();
 	}
 
 }

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImplTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -260,10 +261,12 @@ class WorkFlowDefinitionServiceImplTest {
 	private WorkFlowDefinition sampleWorkFlowDefinition(String name) {
 		WorkFlowParameter workFlowParameter = WorkFlowParameter.builder().key(KEY).description(KEY_DESCRIPTION)
 				.optional(false).type(WorkFlowParameterType.TEXT).build();
+
 		WorkFlowDefinition workFlowDefinition = WorkFlowDefinition.builder().name(name).type(WorkFlowType.ASSESSMENT)
 				.processingType(WorkFlowProcessingType.SEQUENTIAL.name())
-				.parameters(WorkFlowDTOUtil.writeObjectValueAsString(List.of(workFlowParameter))).numberOfWorks(1)
-				.build();
+				.parameters(WorkFlowDTOUtil.writeObjectValueAsString(
+						Map.of(workFlowParameter.getKey(), workFlowParameter.getAsJsonSchema())))
+				.numberOfWorks(1).build();
 		workFlowDefinition.setId(UUID.randomUUID());
 		return workFlowDefinition;
 	}


### PR DESCRIPTION
This commit introduces a new way to consume WorkFlow Parameters and
TaskParameters, so user can define custom validations and extend the Parodos ui
forms with extra information. Workflow definitions will be the same, but
builders has now a jsonschema information, like this:

```
WorkFlowTaskParameter
    .builder()
    .key("user-id")
    .description("The user id")
    .type(WorkFlowTaskParameterType.TEXT)
    .optional(false)
    .JsonSchemaOptions(Map.of(
        "minLength", "1",
        "maxLength", "64"))
    .build());
```

The controller will export the data as a Map, and with jsonschema default
information:

```

{
    "id": "778267a0-6729-4a3c-a97e-6785b377f36e",
    "name": "simpleSequentialWorkFlow_INFRASTRUCTURE_WORKFLOW",
    "type": "INFRASTRUCTURE",
    "processingType": "SEQUENTIAL",
    "author": null,
    "createDate": "2023-03-21T11:52:11.588+00:00",
    "modifyDate": "2023-03-21T11:52:11.588+00:00",
    "works": [
      {
        "id": "61b443e9-b746-4ac9-872f-ab5063c1db85",
        "name": "restCallTask",
        "workType": "TASK",
        "parameters": {
          "payload": {
            "format": "text",
            "description": "Json of what to provide for data. (ie: 'Hello!')",
            "type": "string",
            "required": "true"
          },
          "user-id": {
            "format": "text",
            "description": "The user id",
            "type": "string",
            "required": "true"
          },
          "url": {
            "format": "url",
            "description": "The Url of the service (ie: https://httpbin.org/post",
            "type": "string",
            "required": "true"
          }
        },
        "outputs": [
          "HTTP2XX",
          "OTHER"
        ]
      },
      {
        "id": "71b3f1de-e801-4aa2-936e-419ce93704bc",
        "name": "loggingTask",
        "workType": "TASK",
        "parameters": {
          "user-id": {
            "minLength": "1",
            "format": "text",
            "description": "The user id",
            "type": "string",
            "required": "true",
            "maxLength": "64"
          },
          "api-server": {
            "format": "url",
            "description": "The api server",
            "type": "string",
            "required": "true"
          }
        },
        "outputs": [
          "OTHER"
        ]
      }
    ]
}
```

This will allow users to have better integration with end users.

Fix [FLPATH-193](https://issues.redhat.com//browse/FLPATH-193)
