### PR TITLE
Decouple examples from service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
             ${{ github.workspace }}/coverage/target/site/jacoco-aggregate/jacoco.xml
             ${{ github.workspace }}/notification-service/target/*.jar
             ${{ github.workspace }}/workflow-service/target/*.jar
+            ${{ github.workspace }}/workflow-examples/target/*.jar
 
       - name: Save Maven cache
         uses: skjolber/maven-cache-github-action@v1

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,9 @@ docker-stop: ## Stop notification and workflow services
 
 JAVA_ARGS = -Dspring.profiles.active=local
 run-workflow-service: java-checks ## Run local workflow service
-	java -jar $(JAVA_ARGS) workflow-service/target/workflow-service-$(VERSION).jar
+	java -jar $(JAVA_ARGS) \
+		-Dloader.path=workflow-examples/target/workflow-examples-$(VERSION)-jar-with-dependencies.jar \
+		workflow-service/target/workflow-service-$(VERSION).jar
 
 run-notification-service: java-checks ## Run local notification service
 	java -jar $(JAVA_ARGS) notification-service/target/notification-service-$(VERSION).jar

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,12 +12,13 @@ services:
 
   workflow-service:
     build:
-      context: ../workflow-service
-      dockerfile: ./Dockerfile
+      context: ../
+      dockerfile: ./workflow-service/Dockerfile
     container_name: workflow-service
     ports:
       - 9000:8080
     environment:
       - SPRING_PROFILES_ACTIVE=local
+      - LOADER_PATH=./workflow-examples.jar
     depends_on:
       - notification-service

--- a/workflow-examples/pom.xml
+++ b/workflow-examples/pom.xml
@@ -112,6 +112,25 @@
                     <reportFormat>html</reportFormat>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>assemble-all</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/workflow-examples/start_workflow_service.sh
+++ b/workflow-examples/start_workflow_service.sh
@@ -1,1 +1,3 @@
-java -jar -Dspring.profiles.active=local ../workflow-service/target/workflow-service-1.0.3-SNAPSHOT.jar
+java -jar -Dspring.profiles.active=local \
+    -Dloader.path=../workflow-examples/target/workflow-examples-1.0.3-SNAPSHOT-jar-with-dependencies.jar \
+    ../workflow-service/target/workflow-service-1.0.3-SNAPSHOT.jar

--- a/workflow-service/Dockerfile
+++ b/workflow-service/Dockerfile
@@ -2,7 +2,8 @@ FROM registry.access.redhat.com/ubi9/openjdk-11-runtime
 
 WORKDIR /app
 
-COPY target/*.jar ./workflow-service.jar
+COPY workflow-service/target/*.jar ./workflow-service.jar
+COPY workflow-examples/target/*jar-with-dependencies.jar ./workflow-examples.jar
 
 EXPOSE 8080
 

--- a/workflow-service/pom.xml
+++ b/workflow-service/pom.xml
@@ -126,11 +126,6 @@
             <artifactId>workflow-engine</artifactId>
             <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>dev.parodos</groupId>
-            <artifactId>workflow-examples</artifactId>
-            <version>${revision}</version>
-        </dependency>
         <!-- END Parodos Library Dependencies -->
         <!-- START Developer Productivity Dependencies -->
         <dependency>
@@ -214,6 +209,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${springframework.boot.version}</version>
+                <configuration>
+                    <layout>ZIP</layout>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -224,4 +222,17 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>local</id>
+            <dependencies>
+                <dependency>
+                    <groupId>dev.parodos</groupId>
+                    <artifactId>workflow-examples</artifactId>
+                    <version>${revision}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/workflow-service/start_workflow_service.sh
+++ b/workflow-service/start_workflow_service.sh
@@ -1,1 +1,3 @@
-java -jar -Dspring.profiles.active=local target/workflow-service-1.0.3-SNAPSHOT.jar
+java -jar -Dspring.profiles.active=local \
+    -Dloader.path=../workflow-examples/target/workflow-examples-1.0.3-SNAPSHOT-jar-with-dependencies.jar \
+    target/workflow-service-1.0.3-SNAPSHOT.jar


### PR DESCRIPTION
The purpose of this PR is to decouple the user's workflows from being built into the workflow-service by using the PropertiesLauncher as the Start-Class of the application.

Extra dependencies can be provided via system property `loader.path`. In addition, to satisfy all runtime dependencies, the workflow-example is being built with a plugin to include all of its dependencies in a single jar.

For local development, a local profile was added to include the workflow-examples dependency in the service's path:

```
mvn clean install -Plocal
```