### PR TITLE
CI: remove a redundant mvn compile on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,15 +20,10 @@ jobs:
       - name: Maven Build
         run: mvn clean package
 
-
-      - name: Build cotainer
-        run: mvn clean package
-
       - name: "Build container images"
         run: |
           make build-images GIT_BRANCH=${GITHUB_REF##*/}
           make tag-images GIT_BRANCH=${GITHUB_REF##*/}
-
 
       - name: Login to quay
         env:


### PR DESCRIPTION
Signed-off-by: Roy Golan <rgolan@redhat.com>
