### PR TITLE
FLPATH-204: cleanup definitions in db before loading new beans

### DIFF
--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowWorkDefinition.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/entity/WorkFlowWorkDefinition.java
@@ -10,6 +10,7 @@ import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
@@ -26,7 +27,7 @@ public class WorkFlowWorkDefinition extends AbstractEntity {
 
 	private UUID workDefinitionId;
 
-	@Enumerated
+	@Enumerated(EnumType.STRING)
 	private WorkType workDefinitionType;
 
 	@ManyToOne(optional = false)

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionService.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionService.java
@@ -46,4 +46,6 @@ public interface WorkFlowDefinitionService {
 	void saveWorkFlowChecker(String workFlowTaskName, String workFlowCheckerName,
 			WorkFlowCheckerDTO workFlowCheckerDTO);
 
+	void cleanAllDefinitions();
+
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
@@ -292,4 +292,11 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 		return workDefinitionResponseDTOs.get(0).getWorks();
 	}
 
+	public void cleanAllDefinitions() {
+		workFlowCheckerMappingDefinitionRepository.deleteAll();
+		workFlowWorkRepository.deleteAll();
+		workFlowTaskDefinitionRepository.deleteAll();
+		workFlowDefinitionRepository.deleteAll();
+	}
+
 }

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/registry/BeanWorkFlowRegistryImpl.java
@@ -87,8 +87,10 @@ public class BeanWorkFlowRegistryImpl implements WorkFlowRegistry<String> {
 
 	@PostConstruct
 	void postInit() {
+		workFlowDefinitionService.cleanAllDefinitions();
 		workFlows.forEach(this::saveWorkFlow);
 		saveChecker(workFlowTasks);
+		log.info("workflow definitions are loaded in database");
 	}
 
 	@Override

--- a/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceDataTest.java
+++ b/workflow-service/src/test/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceDataTest.java
@@ -1,0 +1,80 @@
+package com.redhat.parodos.workflow.definition.service;
+
+import com.redhat.parodos.workflow.definition.entity.WorkFlowCheckerMappingDefinition;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowDefinition;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowTaskDefinition;
+import com.redhat.parodos.workflow.definition.entity.WorkFlowWorkDefinition;
+import com.redhat.parodos.workflow.definition.repository.WorkFlowCheckerMappingDefinitionRepository;
+import com.redhat.parodos.workflow.definition.repository.WorkFlowDefinitionRepository;
+import com.redhat.parodos.workflow.definition.repository.WorkFlowTaskDefinitionRepository;
+import com.redhat.parodos.workflow.definition.repository.WorkFlowWorkRepository;
+import com.redhat.parodos.workflow.enums.WorkFlowType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class WorkFlowDefinitionServiceDataTest {
+
+	@Autowired
+	private TestEntityManager entityManager;
+
+	@Autowired
+	private WorkFlowDefinitionRepository workFlowDefinitionRepository;
+
+	@Autowired
+	private WorkFlowTaskDefinitionRepository workFlowTaskDefinitionRepository;
+
+	@Autowired
+	private WorkFlowCheckerMappingDefinitionRepository workFlowCheckerMappingDefinitionRepository;
+
+	@Autowired
+	private WorkFlowWorkRepository workFlowWorkRepository;
+
+	private WorkFlowDefinitionService workFlowDefinitionService;
+
+	@BeforeEach
+	void init() {
+		workFlowDefinitionService = new WorkFlowDefinitionServiceImpl(workFlowDefinitionRepository,
+				workFlowTaskDefinitionRepository, workFlowCheckerMappingDefinitionRepository, workFlowWorkRepository,
+				new ModelMapper());
+
+		WorkFlowDefinition workFlowDefinition = WorkFlowDefinition.builder().name("test-workflow").numberOfWorks(1)
+				.type(WorkFlowType.INFRASTRUCTURE).build();
+		WorkFlowTaskDefinition workFlowTaskDefinition = WorkFlowTaskDefinition.builder().name("test-workflow-task")
+				.workFlowDefinition(workFlowDefinition).build();
+		WorkFlowCheckerMappingDefinition workFlowCheckerMappingDefinition = WorkFlowCheckerMappingDefinition.builder()
+				.tasks(List.of(workFlowTaskDefinition)).checkWorkFlow(workFlowDefinition).cronExpression("*/5 * * * *")
+				.build();
+		WorkFlowWorkDefinition workFlowWorkDefinition = WorkFlowWorkDefinition.builder()
+				.workDefinitionId(UUID.randomUUID()).workFlowDefinition(workFlowDefinition).build();
+		entityManager.persist(workFlowDefinition);
+		entityManager.persist(workFlowTaskDefinition);
+		entityManager.persist(workFlowCheckerMappingDefinition);
+		entityManager.persist(workFlowWorkDefinition);
+	}
+
+	@Test
+	void cleanAllDefinition_should_returnEmpty_when_DatabaseIsCleaned() {
+		assertThat(workFlowDefinitionRepository.findAll()).hasSize(1);
+		assertThat(workFlowTaskDefinitionRepository.findAll()).hasSize(1);
+		assertThat(workFlowCheckerMappingDefinitionRepository.findAll()).hasSize(1);
+		assertThat(workFlowWorkRepository.findAll()).hasSize(1);
+
+		workFlowDefinitionService.cleanAllDefinitions();
+
+		assertThat(workFlowDefinitionRepository.findAll()).isEmpty();
+		assertThat(workFlowTaskDefinitionRepository.findAll()).isEmpty();
+		assertThat(workFlowCheckerMappingDefinitionRepository.findAll()).isEmpty();
+		assertThat(workFlowWorkRepository.findAll()).isEmpty();
+	}
+
+}


### PR DESCRIPTION
[FLPATH-204](https://issues.redhat.com/browse/FLPATH-204)

update database with new workflow configuration after app restarts

*note:   executions and project table are not cleaned