### PR TITLE
Workflow: parameters as object not as string

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameter.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameter.java
@@ -43,12 +43,12 @@ public class WorkFlowParameter {
 
 	private boolean optional;
 
-	public Map<String, String> getAsJsonSchema() {
+	public Map<String, Object> getAsJsonSchema() {
 		if (this.getType() == null) {
 			return Map.of();
 		}
-		Map<String, String> properties = this.getType().getAsJsonSchema();
-		properties.put("required", String.valueOf(!this.isOptional()));
+		Map<String, Object> properties = this.getType().getAsJsonSchema();
+		properties.put("required", !this.isOptional());
 		properties.put("description", this.getDescription());
 		return properties;
 	}

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterType.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterType.java
@@ -28,8 +28,8 @@ public enum WorkFlowParameterType {
 
 	PASSWORD, TEXT, EMAIL, DATE, NUMBER, URL;
 
-	public Map<String, String> getAsJsonSchema() {
-		Map<String, String> properties = new HashMap<>();
+	public Map<String, Object> getAsJsonSchema() {
+		Map<String, Object> properties = new HashMap<>();
 		switch (this) {
 			case PASSWORD:
 				properties.put("type", "string");

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/WorkFlowTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/WorkFlowTask.java
@@ -56,8 +56,8 @@ public interface WorkFlowTask extends Work {
 
 	}
 
-	default HashMap<String, Map<String, String>> getAsJsonSchema() {
-		HashMap<String, Map<String, String>> result = new HashMap<>();
+	default HashMap<String, Map<String, Object>> getAsJsonSchema() {
+		HashMap<String, Map<String, Object>> result = new HashMap<>();
 		for (WorkFlowTaskParameter workFlowTaskParameter : this.getWorkFlowTaskParameters()) {
 			if (workFlowTaskParameter == null) {
 				continue;
@@ -67,8 +67,8 @@ public interface WorkFlowTask extends Work {
 				continue;
 			}
 
-			Map<String, String> properties = workFlowTaskParameter.getType().getAsJsonSchema();
-			properties.put("required", String.valueOf(!workFlowTaskParameter.isOptional()));
+			Map<String, Object> properties = workFlowTaskParameter.getType().getAsJsonSchema();
+			properties.put("required", !workFlowTaskParameter.isOptional());
 			properties.put("description", workFlowTaskParameter.getDescription());
 			if (workFlowTaskParameter.getJsonSchemaOptions() != null) {
 				properties.putAll(workFlowTaskParameter.getJsonSchemaOptions());

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameter.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameter.java
@@ -43,6 +43,6 @@ public class WorkFlowTaskParameter {
 
 	private WorkFlowTaskParameterType type;
 
-	private Map<String, String> JsonSchemaOptions;
+	private Map<String, Object> JsonSchemaOptions;
 
 }

--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterType.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterType.java
@@ -29,8 +29,8 @@ public enum WorkFlowTaskParameterType {
 
 	PASSWORD, TEXT, EMAIL, DATE, NUMBER, URL;
 
-	public Map<String, String> getAsJsonSchema() {
-		Map<String, String> properties = new HashMap<>();
+	public Map<String, Object> getAsJsonSchema() {
+		Map<String, Object> properties = new HashMap<>();
 		switch (this) {
 			case PASSWORD:
 				properties.put("type", "string");

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTest.java
@@ -16,21 +16,21 @@ public class WorkFlowParameterTest extends TestCase {
 		WorkFlowParameter parameters = WorkFlowParameter.builder().key(key).description(description)
 				.type(WorkFlowParameterType.TEXT).build();
 		// when
-		Map<String, String> result = parameters.getAsJsonSchema();
+		Map<String, Object> result = parameters.getAsJsonSchema();
 		// then
 		assertNotNull(result);
 		assertEquals(result.size(), 4);
 		assertEquals(result.get("type"), "string");
 		assertEquals(result.get("description"), description);
 		assertEquals(result.get("format"), "text");
-		assertEquals(result.get("required"), "true");
+		assertEquals(result.get("required"), true);
 	}
 
 	public void testGetAsJsonSchemaWithoutType() {
 		// given
 		WorkFlowParameter parameters = WorkFlowParameter.builder().key(key).description(description).build();
 		// when
-		Map<String, String> result = parameters.getAsJsonSchema();
+		Map<String, Object> result = parameters.getAsJsonSchema();
 		// then
 		assertNotNull(result);
 		assertEquals(result.size(), 0);

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTypeTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/parameter/WorkFlowParameterTypeTest.java
@@ -17,7 +17,7 @@ public class WorkFlowParameterTypeTest extends TestCase {
 				WorkFlowParameterType.EMAIL, WorkFlowParameterType.NUMBER, WorkFlowParameterType.URL,
 				WorkFlowParameterType.DATE };
 
-		List<Map<String, String>> outputs = new ArrayList<>();
+		List<Map<String, Object>> outputs = new ArrayList<>();
 		for (WorkFlowParameterType inputValue : inputValues) {
 			outputs.add(inputValue.getAsJsonSchema());
 		}

--- a/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterTypeTest.java
+++ b/parodos-model-api/src/test/java/com/redhat/parodos/workflow/task/parameter/WorkFlowTaskParameterTypeTest.java
@@ -16,7 +16,7 @@ public class WorkFlowTaskParameterTypeTest extends TestCase {
 				WorkFlowTaskParameterType.EMAIL, WorkFlowTaskParameterType.NUMBER, WorkFlowTaskParameterType.URL,
 				WorkFlowTaskParameterType.DATE };
 
-		List<Map<String, String>> outputs = new ArrayList<>();
+		List<Map<String, Object>> outputs = new ArrayList<>();
 		for (WorkFlowTaskParameterType inputValue : inputValues) {
 			outputs.add(inputValue.getAsJsonSchema());
 		}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkDefinitionResponseDTO.java
@@ -63,7 +63,7 @@ public class WorkDefinitionResponseDTO {
 	private List<WorkDefinitionResponseDTO> works;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	private Map<String, Map<String, String>> parameters;
+	private Map<String, Map<String, Object>> parameters;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<WorkFlowTaskOutput> outputs;
@@ -78,7 +78,7 @@ public class WorkDefinitionResponseDTO {
 				return this;
 			}
 			this.parameters(WorkFlowDTOUtil.readStringAsObject(parameters,
-					new TypeReference<Map<String, Map<String, String>>>() {
+					new TypeReference<Map<String, Map<String, Object>>>() {
 					}, Map.of()));
 			return this;
 		}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/dto/WorkFlowDefinitionResponseDTO.java
@@ -59,7 +59,7 @@ public class WorkFlowDefinitionResponseDTO {
 	private Date modifyDate;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
-	private Map<String, Map<String, String>> parameters;
+	private Map<String, Map<String, Object>> parameters;
 
 	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<WorkDefinitionResponseDTO> works;
@@ -71,7 +71,7 @@ public class WorkFlowDefinitionResponseDTO {
 				return this;
 			}
 			this.parameters(WorkFlowDTOUtil.readStringAsObject(parameters,
-					new TypeReference<Map<String, Map<String, String>>>() {
+					new TypeReference<Map<String, Map<String, Object>>>() {
 					}, Map.of()));
 			return this;
 		}

--- a/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
+++ b/workflow-service/src/main/java/com/redhat/parodos/workflow/definition/service/WorkFlowDefinitionServiceImpl.java
@@ -82,8 +82,8 @@ public class WorkFlowDefinitionServiceImpl implements WorkFlowDefinitionService 
 		this.modelMapper = modelMapper;
 	}
 
-	private HashMap<String, Map<String, String>> convertWorkFlowParameters(List<WorkFlowParameter> workFlowParameters) {
-		HashMap<String, Map<String, String>> result = new HashMap<>();
+	private HashMap<String, Map<String, Object>> convertWorkFlowParameters(List<WorkFlowParameter> workFlowParameters) {
+		HashMap<String, Map<String, Object>> result = new HashMap<>();
 		for (WorkFlowParameter workFlowParameter : workFlowParameters) {
 			if (workFlowParameter == null)
 				continue;


### PR DESCRIPTION
Required is set as "true" as string, but Backstage is not rendering it well, so moving to a native type and using Object instead of String.

Example output:
```
{
    "id": "ffe20407-7af4-4a14-b6a8-e1c4c02cfaf5",
    "name": "simpleSequentialWorkFlow_INFRASTRUCTURE_WORKFLOW",
    "type": "INFRASTRUCTURE",
    "processingType": "SEQUENTIAL",
    "author": null,
    "createDate": "2023-03-23T14:05:40.325+00:00",
    "modifyDate": "2023-03-23T14:05:40.325+00:00",
    "works": [
      {
        "id": "749705aa-7a2d-4ff2-8c7c-40369dfb50d8",
        "name": "restCallTask",
        "workType": "TASK",
        "parameters": {
          "payload": {
            "format": "text",
            "description": "Json of what to provide for data. (ie: 'Hello!')",
            "type": "string",
            "required": true
          },
          "user-id": {
            "format": "text",
            "description": "The user id",
            "type": "string",
            "required": true
          },
          "url": {
            "format": "url",
            "description": "The Url of the service (ie: https://httpbin.org/post",
            "type": "string",
            "required": true
          }
        },
        "outputs": [
          "HTTP2XX",
          "OTHER"
        ]
      },
      {
        "id": "191a4f56-0653-4799-864b-9633141951ce",
        "name": "loggingTask",
        "workType": "TASK",
        "parameters": {
          "user-id": {
            "minLength": 1,
            "format": "text",
            "description": "The user id",
            "type": "string",
            "required": true,
            "maxLength": 64
          },
          "api-server": {
            "format": "url",
            "description": "The api server",
            "type": "string",
            "required": true
          }
        },
        "outputs": [
          "OTHER"
        ]
      }
    ]
  }
```

Let me highlight the required, minLength and maxLength parameters that are no longer string.

Related  to [FLPATH-193](https://issues.redhat.com//browse/FLPATH-193)