### PR TITLE
Fix: return workreport from running the escalation workflow

### DIFF
--- a/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/checker/BaseWorkFlowCheckerTask.java
+++ b/parodos-model-api/src/main/java/com/redhat/parodos/workflow/task/checker/BaseWorkFlowCheckerTask.java
@@ -75,7 +75,7 @@ public abstract class BaseWorkFlowCheckerTask extends BaseWorkFlowTask {
 		if (escalationWorkflow != null && report.getStatus() == WorkStatus.FAILED
 				&& new Date().getTime() > expectedCompletionDate) {
 			// run escalation if SLA is exceeded
-			WorkFlowEngineBuilder.aNewWorkFlowEngine().build().run(escalationWorkflow, workContext);
+			return WorkFlowEngineBuilder.aNewWorkFlowEngine().build().run(escalationWorkflow, workContext);
 		}
 		return report;
 	}


### PR DESCRIPTION
I noticed that when running a check flow that has an escalation flow associated to it, the parent `executer` does not return the workreport from running the escalation flow. This PR fixes that so that the return workreport is from the escalation flow and not from the check flow.

@lshannon @RichardW98 PTAL.

/Jordi